### PR TITLE
chore: adjust timeout setup

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -40,7 +40,7 @@ switch (process.env.TEST_ENV) {
 
 const config: PlaywrightTestConfig = {
   testDir: './tests',
-  timeout: 2 * MS_PER_MIN,
+  timeout: 10 * MS_PER_MIN,
   expect: {
     timeout: 30 * MS_PER_SEC,
   },
@@ -61,7 +61,7 @@ const config: PlaywrightTestConfig = {
   ],
   use: {
     viewport: { width: 1920, height: 1080 },
-    actionTimeout: 0,
+    actionTimeout: 30 * MS_PER_SEC,
     baseURL: BASE_URL,
     trace: 'retain-on-failure',
     screenshot: 'only-on-failure',

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -61,7 +61,7 @@ const config: PlaywrightTestConfig = {
   ],
   use: {
     viewport: { width: 1920, height: 1080 },
-    actionTimeout: 30 * MS_PER_SEC,
+    actionTimeout: 1 * MS_PER_MIN,
     baseURL: BASE_URL,
     trace: 'retain-on-failure',
     screenshot: 'only-on-failure',

--- a/tests/fields/textField.spec.ts
+++ b/tests/fields/textField.spec.ts
@@ -5,7 +5,6 @@ import { TextField } from '../../models/textField';
 import { AddContentPage } from '../../pageObjectModels/content/addContentPage';
 import { EditContentPage } from '../../pageObjectModels/content/editContentPage';
 import { ViewContentPage } from '../../pageObjectModels/content/viewContentPage';
-import { MS_PER_MIN } from '../../playwright.config';
 import { AnnotationType } from '../annotations';
 
 test.describe('text field', () => {
@@ -355,9 +354,6 @@ test.describe('text field', () => {
     app,
     testUserPage,
   }) => {
-    // test requires significant setup
-    test.setTimeout(4 * MS_PER_MIN);
-
     test.info().annotations.push({
       type: AnnotationType.TestId,
       description: 'Test-99',
@@ -427,9 +423,6 @@ test.describe('text field', () => {
     app,
     testUserPage,
   }) => {
-    // test requires significant setup
-    test.setTimeout(4 * MS_PER_MIN);
-
     test.info().annotations.push({
       type: AnnotationType.TestId,
       description: 'Test-810',
@@ -495,9 +488,6 @@ test.describe('text field', () => {
   });
 
   test('Make a Text Field public', async ({ sysAdminPage, role, appAdminPage, app, testUserPage }) => {
-    // test requires significant setup
-    test.setTimeout(4 * MS_PER_MIN);
-
     test.info().annotations.push({
       type: AnnotationType.TestId,
       description: 'Test-105',


### PR DESCRIPTION
I don't care if a test takes a while as long as the test is doing something. I do care if a test is doing nothing for a long time. Such as being hung waitning to assert or take an action. This commit adjusts the timeout setup to be more forgiving of slow tests and more strict on tests that actually have a problem.

+ test timeout extended to 10 minutes
+ action timeout limited to 60 seconds
  + being generous here to account for navigations
    between some pages that take time to load like roles
    page
