### PR TITLE
fix: address flakiness exposed on v27.1 upgrade

### DIFF
--- a/componentObjectModels/modals/addOrEditFieldModal.ts
+++ b/componentObjectModels/modals/addOrEditFieldModal.ts
@@ -11,6 +11,7 @@ export class AddOrEditFieldModal extends AddOrEditLayoutItemModal {
   readonly usageTabButton: Locator;
   readonly securityTab: LayoutItemSecurityTab;
   readonly usageTab: LayoutItemUsageTab;
+  private readonly addOrEditPathRegex: RegExp = /\/Admin\/App\/\d+\/Field\/(AddUsingSettings|\d+\/Edit)/;
 
   // FIX: Shouldn't need to explicitly pass frameNumber here.
   // https://corp.onspring.com/Content/8/4092
@@ -22,5 +23,12 @@ export class AddOrEditFieldModal extends AddOrEditLayoutItemModal {
     this.usageTabButton = this.frame.getByRole('tab', { name: 'Usage' });
     this.securityTab = new FieldSecurityTab(this.frame);
     this.usageTab = new LayoutItemUsageTab();
+  }
+
+  async save() {
+    const addOrEditFieldResponse = this.saveButton.page().waitForResponse(this.addOrEditPathRegex);
+
+    await this.saveButton.click();
+    await addOrEditFieldResponse;
   }
 }

--- a/componentObjectModels/modals/addOrEditFormattedTextBlockModal.ts
+++ b/componentObjectModels/modals/addOrEditFormattedTextBlockModal.ts
@@ -1,9 +1,9 @@
 import { Locator, Page } from '@playwright/test';
 import { FormattedTextBlockGeneralTab } from '../tabs/formattedTextBlockGeneralTab';
+import { FormattedTextBlockSecurityTab } from '../tabs/formattedTextBlockSecurityTab';
 import { LayoutItemSecurityTab } from '../tabs/layoutItemSecurityTab';
 import { LayoutItemUsageTab } from '../tabs/layoutItemUsageTab';
 import { AddOrEditLayoutItemModal } from './addOrEditLayoutItemModal';
-import { FormattedTextBlockSecurityTab } from '../tabs/formattedTextBlockSecurityTab';
 
 export class AddOrEditFormattedBlockModal extends AddOrEditLayoutItemModal {
   private readonly frame: Locator;
@@ -13,6 +13,7 @@ export class AddOrEditFormattedBlockModal extends AddOrEditLayoutItemModal {
   readonly securityTab: LayoutItemSecurityTab;
   readonly usageTab: LayoutItemUsageTab;
   readonly generalTab: FormattedTextBlockGeneralTab;
+  private readonly addOrEditPathRegex: RegExp = /\/Admin\/App\/\d+\/LayoutObject\/(AddTextObject|\d+\/EditTextObject)/;
 
   constructor(page: Page) {
     super(page);
@@ -23,5 +24,12 @@ export class AddOrEditFormattedBlockModal extends AddOrEditLayoutItemModal {
     this.generalTab = new FormattedTextBlockGeneralTab(this.frame);
     this.securityTab = new FormattedTextBlockSecurityTab(this.frame);
     this.usageTab = new LayoutItemUsageTab();
+  }
+
+  async save() {
+    const addOrEditTextBlockResponse = this.saveButton.page().waitForResponse(this.addOrEditPathRegex);
+
+    await this.saveButton.click();
+    await addOrEditTextBlockResponse;
   }
 }

--- a/componentObjectModels/modals/addOrEditLayoutItemModal.ts
+++ b/componentObjectModels/modals/addOrEditLayoutItemModal.ts
@@ -8,9 +8,15 @@ export abstract class AddOrEditLayoutItemModal {
   abstract readonly usageTabButton: Locator;
   abstract readonly securityTab: LayoutItemSecurityTab;
   abstract readonly usageTab: LayoutItemUsageTab;
-  readonly saveButton: Locator;
+  protected readonly saveButton: Locator;
 
   constructor(page: Page) {
     this.saveButton = page.getByRole('button', { name: 'Save' });
   }
+
+  /**
+   * Saves the layout item by clicking the Save button and waiting for the response.
+   * @returns {Promise<void>}
+   */
+  abstract save(): Promise<void>;
 }

--- a/componentObjectModels/tabs/appLayoutTab.ts
+++ b/componentObjectModels/tabs/appLayoutTab.ts
@@ -109,7 +109,7 @@ export class AppLayoutTab extends LayoutItemCreator {
     await this.addFieldButton.click();
     await this.addLayoutItemMenu.selectItem(item.type);
     await this.addLayoutItemDialog.continueButton.click();
-
+    await this.page.waitForLoadState('networkidle');
     await this.addLayoutItem(item);
   }
 
@@ -137,6 +137,7 @@ export class AppLayoutTab extends LayoutItemCreator {
     }
 
     await this.addLayoutItemDialog.continueButton.click();
+    await this.page.waitForLoadState('networkidle');
     await this.addLayoutItem(item, 1);
   }
 }

--- a/componentObjectModels/tabs/appLayoutTab.ts
+++ b/componentObjectModels/tabs/appLayoutTab.ts
@@ -91,8 +91,7 @@ export class AppLayoutTab extends LayoutItemCreator {
     await modal.securityTabButton.click();
     await modal.securityTab.setPermissions(item.permissions);
 
-    await modal.saveButton.click();
-    await this.page.waitForLoadState('networkidle');
+    await modal.save();
   }
 
   /**

--- a/componentObjectModels/tabs/referenceFieldGeneralTab.ts
+++ b/componentObjectModels/tabs/referenceFieldGeneralTab.ts
@@ -4,15 +4,20 @@ import { FieldGeneralTab } from './fieldGeneralTab';
 
 export class ReferenceFieldGeneralTab extends FieldGeneralTab {
   readonly referenceSelect: Locator;
+  readonly gridFieldsSelect: Locator;
+  private readonly referenceDisplayFieldsPathRegex: RegExp;
 
   constructor(frame: FrameLocator) {
     super(frame);
     this.referenceSelect = this.frame.getByRole('listbox', { name: 'Reference' });
+    this.gridFieldsSelect = this.frame.locator('td:has-text("Grid Fields") + td div.onx-selector');
+    this.referenceDisplayFieldsPathRegex = /\/Admin\/App\/\d+\/Field\/ReferenceDisplayFields/;
   }
 
   async selectReference(reference: string) {
     await this.referenceSelect.click();
     await this.frame.getByRole('option', { name: reference }).click();
+    await this.referenceSelect.page().waitForResponse(this.referenceDisplayFieldsPathRegex);
   }
 
   async fillOutGeneralTab(referenceField: ReferenceField) {

--- a/tests/fields/attachmentField.spec.ts
+++ b/tests/fields/attachmentField.spec.ts
@@ -50,10 +50,11 @@ test.describe('attachment field', () => {
       const fieldRow = appAdminPage.layoutTab.fieldsAndObjectsGrid.getByRole('row', { name: field.name });
       await fieldRow.hover();
       await fieldRow.getByTitle('Copy').click();
+      await appAdminPage.page.waitForLoadState('networkidle');
 
       const addAttachmentFieldModal = appAdminPage.layoutTab.getLayoutItemModal('Attachment');
       await expect(addAttachmentFieldModal.generalTab.fieldInput).toHaveValue(copiedFieldName);
-      await addAttachmentFieldModal.saveButton.click();
+      await addAttachmentFieldModal.save();
     });
 
     await test.step('Verify the field was copied', async () => {
@@ -87,12 +88,13 @@ test.describe('attachment field', () => {
       await appAdminPage.layoutTab.addLayoutItemDialog.selectDropdown.click();
       await appAdminPage.layoutTab.addLayoutItemDialog.getLayoutItemToCopy(field.name).click();
       await appAdminPage.layoutTab.addLayoutItemDialog.continueButton.click();
+      await appAdminPage.page.waitForLoadState('networkidle');
 
       const addAttachmentFieldModal = appAdminPage.layoutTab.getLayoutItemModal('Attachment');
 
       await expect(addAttachmentFieldModal.generalTab.fieldInput).toHaveValue(copiedFieldName);
 
-      await addAttachmentFieldModal.saveButton.click();
+      await addAttachmentFieldModal.save();
     });
 
     await test.step('Verify the field was copied', async () => {
@@ -162,12 +164,13 @@ test.describe('attachment field', () => {
       await appAdminPage.layoutTab.addLayoutItemDialog.selectDropdown.click();
       await appAdminPage.layoutTab.addLayoutItemDialog.getLayoutItemToCopy(field.name).click();
       await appAdminPage.layoutTab.addLayoutItemDialog.continueButton.click();
+      await appAdminPage.page.waitForLoadState('networkidle');
 
       const addAttachmentFieldModal = appAdminPage.layoutTab.layoutDesignerModal.getLayoutItemModal('Attachment', 1);
 
       await expect(addAttachmentFieldModal.generalTab.fieldInput).toHaveValue(copiedFieldName);
 
-      await addAttachmentFieldModal.saveButton.click();
+      await addAttachmentFieldModal.save();
     });
 
     await test.step('Verify the field was copied', async () => {
@@ -304,10 +307,11 @@ test.describe('attachment field', () => {
       const fieldRow = appAdminPage.layoutTab.fieldsAndObjectsGrid.getByRole('row', { name: field.name });
       await fieldRow.hover();
       await fieldRow.getByTitle('Edit').click();
+      await appAdminPage.page.waitForLoadState('networkidle');
 
       const editAttachmentFieldModal = appAdminPage.layoutTab.getLayoutItemModal('Attachment');
       await editAttachmentFieldModal.generalTab.fieldInput.fill(updatedFieldName);
-      await editAttachmentFieldModal.saveButton.click();
+      await editAttachmentFieldModal.save();
     });
 
     await test.step('Verify the field was updated', async () => {
@@ -561,11 +565,12 @@ test.describe('attachment field', () => {
       const fieldRow = appAdminPage.layoutTab.fieldsAndObjectsGrid.getByRole('row', { name: field.name });
       await fieldRow.hover();
       await fieldRow.getByTitle('Edit').click();
+      await appAdminPage.page.waitForLoadState('networkidle');
 
       const editAttachmentFieldModal = appAdminPage.layoutTab.getLayoutItemModal('Attachment');
       await editAttachmentFieldModal.securityTabButton.click();
       await editAttachmentFieldModal.securityTab.setPermissions([]);
-      await editAttachmentFieldModal.saveButton.click();
+      await editAttachmentFieldModal.save();
     });
 
     await test.step('Navigate to created record again as test user', async () => {

--- a/tests/fields/dateField.spec.ts
+++ b/tests/fields/dateField.spec.ts
@@ -51,11 +51,12 @@ test.describe('date/time field', () => {
 
       await fieldRow.hover();
       await fieldRow.getByTitle('Copy').click();
+      await appAdminPage.page.waitForLoadState('networkidle');
 
       const addDateFieldModal = appAdminPage.layoutTab.getLayoutItemModal('Date/Time');
 
       await expect(addDateFieldModal.generalTab.fieldInput).toHaveValue(copiedFieldName);
-      await addDateFieldModal.saveButton.click();
+      await addDateFieldModal.save();
     });
 
     await test.step('Verify the field was copied', async () => {
@@ -89,12 +90,13 @@ test.describe('date/time field', () => {
       await appAdminPage.layoutTab.addLayoutItemDialog.selectDropdown.click();
       await appAdminPage.layoutTab.addLayoutItemDialog.getLayoutItemToCopy(field.name).click();
       await appAdminPage.layoutTab.addLayoutItemDialog.continueButton.click();
+      await appAdminPage.page.waitForLoadState('networkidle');
 
       const addDateFieldModal = appAdminPage.layoutTab.getLayoutItemModal('Date/Time');
 
       await expect(addDateFieldModal.generalTab.fieldInput).toHaveValue(copiedFieldName);
 
-      await addDateFieldModal.saveButton.click();
+      await addDateFieldModal.save();
     });
 
     await test.step('Verify the field was copied', async () => {
@@ -164,12 +166,13 @@ test.describe('date/time field', () => {
       await appAdminPage.layoutTab.addLayoutItemDialog.selectDropdown.click();
       await appAdminPage.layoutTab.addLayoutItemDialog.getLayoutItemToCopy(field.name).click();
       await appAdminPage.layoutTab.addLayoutItemDialog.continueButton.click();
+      await appAdminPage.page.waitForLoadState('networkidle');
 
       const addDateFieldModal = appAdminPage.layoutTab.layoutDesignerModal.getLayoutItemModal('Date/Time', 1);
 
       await expect(addDateFieldModal.generalTab.fieldInput).toHaveValue(copiedFieldName);
 
-      await addDateFieldModal.saveButton.click();
+      await addDateFieldModal.save();
     });
 
     await test.step('Verify the field was copied', async () => {
@@ -338,10 +341,11 @@ test.describe('date/time field', () => {
       const fieldRow = appAdminPage.layoutTab.fieldsAndObjectsGrid.getByRole('row', { name: field.name });
       await fieldRow.hover();
       await fieldRow.getByTitle('Edit').click();
+      await appAdminPage.page.waitForLoadState('networkidle');
 
       const editDateFieldModal = appAdminPage.layoutTab.getLayoutItemModal('Date/Time');
       await editDateFieldModal.generalTab.fieldInput.fill(updatedFieldName);
-      await editDateFieldModal.saveButton.click();
+      await editDateFieldModal.save();
     });
 
     await test.step('Verify the field was updated', async () => {
@@ -558,11 +562,12 @@ test.describe('date/time field', () => {
       const fieldRow = appAdminPage.layoutTab.fieldsAndObjectsGrid.getByRole('row', { name: field.name });
       await fieldRow.hover();
       await fieldRow.getByTitle('Edit').click();
+      await appAdminPage.page.waitForLoadState('networkidle');
 
       const editDateFieldModal = appAdminPage.layoutTab.getLayoutItemModal('Date/Time');
       await editDateFieldModal.securityTabButton.click();
       await editDateFieldModal.securityTab.setPermissions([]);
-      await editDateFieldModal.saveButton.click();
+      await editDateFieldModal.save();
     });
 
     await test.step('Navigate to created record again as test user', async () => {

--- a/tests/fields/dateFormulaField.spec.ts
+++ b/tests/fields/dateFormulaField.spec.ts
@@ -57,11 +57,12 @@ test.describe('date formula field', () => {
 
       await fieldRow.hover();
       await fieldRow.getByTitle('Copy').click();
+      await appAdminPage.page.waitForLoadState('networkidle');
 
       const addDateFormulaFieldModal = appAdminPage.layoutTab.getLayoutItemModal('Formula');
 
       await expect(addDateFormulaFieldModal.generalTab.fieldInput).toHaveValue(copiedFieldName);
-      await addDateFormulaFieldModal.saveButton.click();
+      await addDateFormulaFieldModal.save();
     });
 
     await test.step('Verify the field was copied', async () => {
@@ -98,12 +99,13 @@ test.describe('date formula field', () => {
       await appAdminPage.layoutTab.addLayoutItemDialog.selectDropdown.click();
       await appAdminPage.layoutTab.addLayoutItemDialog.getLayoutItemToCopy(field.name).click();
       await appAdminPage.layoutTab.addLayoutItemDialog.continueButton.click();
+      await appAdminPage.page.waitForLoadState('networkidle');
 
       const addDateFormulaFieldModal = appAdminPage.layoutTab.getLayoutItemModal('Formula');
 
       await expect(addDateFormulaFieldModal.generalTab.fieldInput).toHaveValue(copiedFieldName);
 
-      await addDateFormulaFieldModal.saveButton.click();
+      await addDateFormulaFieldModal.save();
     });
 
     await test.step('Verify the field was copied', async () => {
@@ -177,12 +179,13 @@ test.describe('date formula field', () => {
       await appAdminPage.layoutTab.addLayoutItemDialog.selectDropdown.click();
       await appAdminPage.layoutTab.addLayoutItemDialog.getLayoutItemToCopy(field.name).click();
       await appAdminPage.layoutTab.addLayoutItemDialog.continueButton.click();
+      await appAdminPage.page.waitForLoadState('networkidle');
 
       const addDateFormulaFieldModal = appAdminPage.layoutTab.layoutDesignerModal.getLayoutItemModal('Formula', 1);
 
       await expect(addDateFormulaFieldModal.generalTab.fieldInput).toHaveValue(copiedFieldName);
 
-      await addDateFormulaFieldModal.saveButton.click();
+      await addDateFormulaFieldModal.save();
     });
 
     await test.step('Verify the field was copied', async () => {
@@ -328,10 +331,11 @@ test.describe('date formula field', () => {
       const fieldRow = appAdminPage.layoutTab.fieldsAndObjectsGrid.getByRole('row', { name: field.name });
       await fieldRow.hover();
       await fieldRow.getByTitle('Edit').click();
+      await appAdminPage.page.waitForLoadState('networkidle');
 
       const editDateFormulaFieldModal = appAdminPage.layoutTab.getLayoutItemModal('Formula');
       await editDateFormulaFieldModal.generalTab.fieldInput.fill(updatedFieldName);
-      await editDateFormulaFieldModal.saveButton.click();
+      await editDateFormulaFieldModal.save();
     });
 
     await test.step('Verify the field was updated', async () => {
@@ -565,11 +569,12 @@ test.describe('date formula field', () => {
       const fieldRow = appAdminPage.layoutTab.fieldsAndObjectsGrid.getByRole('row', { name: field.name });
       await fieldRow.hover();
       await fieldRow.getByTitle('Edit').click();
+      await appAdminPage.page.waitForLoadState('networkidle');
 
       const editDateFormulaFieldModal = appAdminPage.layoutTab.getLayoutItemModal('Formula');
       await editDateFormulaFieldModal.securityTabButton.click();
       await editDateFormulaFieldModal.securityTab.setPermissions([]);
-      await editDateFormulaFieldModal.saveButton.click();
+      await editDateFormulaFieldModal.save();
     });
 
     await test.step('Navigate to created record again as test user', async () => {

--- a/tests/fields/imageField.spec.ts
+++ b/tests/fields/imageField.spec.ts
@@ -50,10 +50,11 @@ test.describe('image field', () => {
       const fieldRow = appAdminPage.layoutTab.fieldsAndObjectsGrid.getByRole('row', { name: field.name });
       await fieldRow.hover();
       await fieldRow.getByTitle('Copy').click();
+      await appAdminPage.page.waitForLoadState('networkidle');
 
       const addImageFieldModal = appAdminPage.layoutTab.getLayoutItemModal('Image');
       await expect(addImageFieldModal.generalTab.fieldInput).toHaveValue(copiedFieldName);
-      await addImageFieldModal.saveButton.click();
+      await addImageFieldModal.save();
     });
 
     await test.step('Verify the field was copied', async () => {
@@ -87,12 +88,13 @@ test.describe('image field', () => {
       await appAdminPage.layoutTab.addLayoutItemDialog.selectDropdown.click();
       await appAdminPage.layoutTab.addLayoutItemDialog.getLayoutItemToCopy(field.name).click();
       await appAdminPage.layoutTab.addLayoutItemDialog.continueButton.click();
+      await appAdminPage.page.waitForLoadState('networkidle');
 
       const addImageFieldModal = appAdminPage.layoutTab.getLayoutItemModal('Image');
 
       await expect(addImageFieldModal.generalTab.fieldInput).toHaveValue(copiedFieldName);
 
-      await addImageFieldModal.saveButton.click();
+      await addImageFieldModal.save();
     });
 
     await test.step('Verify the field was copied', async () => {
@@ -160,12 +162,13 @@ test.describe('image field', () => {
       await appAdminPage.layoutTab.addLayoutItemDialog.selectDropdown.click();
       await appAdminPage.layoutTab.addLayoutItemDialog.getLayoutItemToCopy(field.name).click();
       await appAdminPage.layoutTab.addLayoutItemDialog.continueButton.click();
+      await appAdminPage.page.waitForLoadState('networkidle');
 
       const addImageFieldModal = appAdminPage.layoutTab.layoutDesignerModal.getLayoutItemModal('Image', 1);
 
       await expect(addImageFieldModal.generalTab.fieldInput).toHaveValue(copiedFieldName);
 
-      await addImageFieldModal.saveButton.click();
+      await addImageFieldModal.save();
     });
 
     await test.step('Verify the field was copied', async () => {
@@ -302,10 +305,11 @@ test.describe('image field', () => {
       const fieldRow = appAdminPage.layoutTab.fieldsAndObjectsGrid.getByRole('row', { name: field.name });
       await fieldRow.hover();
       await fieldRow.getByTitle('Edit').click();
+      await appAdminPage.page.waitForLoadState('networkidle');
 
       const editImageFieldModal = appAdminPage.layoutTab.getLayoutItemModal('Image');
       await editImageFieldModal.generalTab.fieldInput.fill(updatedFieldName);
-      await editImageFieldModal.saveButton.click();
+      await editImageFieldModal.save();
     });
 
     await test.step('Verify the field was updated', async () => {
@@ -560,11 +564,12 @@ test.describe('image field', () => {
       const fieldRow = appAdminPage.layoutTab.fieldsAndObjectsGrid.getByRole('row', { name: field.name });
       await fieldRow.hover();
       await fieldRow.getByTitle('Edit').click();
+      await appAdminPage.page.waitForLoadState('networkidle');
 
       const editImageFieldModal = appAdminPage.layoutTab.getLayoutItemModal('Image');
       await editImageFieldModal.securityTabButton.click();
       await editImageFieldModal.securityTab.setPermissions([]);
-      await editImageFieldModal.saveButton.click();
+      await editImageFieldModal.save();
     });
 
     await test.step('Navigate to created record again as test user', async () => {

--- a/tests/fields/listField.spec.ts
+++ b/tests/fields/listField.spec.ts
@@ -57,11 +57,12 @@ test.describe('list field', () => {
 
       await fieldRow.hover();
       await fieldRow.getByTitle('Copy').click();
+      await appAdminPage.page.waitForLoadState('networkidle');
 
       const addListFieldModal = appAdminPage.layoutTab.getLayoutItemModal('List');
 
       await expect(addListFieldModal.generalTab.fieldInput).toHaveValue(copiedFieldName);
-      await addListFieldModal.saveButton.click();
+      await addListFieldModal.save();
     });
 
     await test.step('Verify the field was copied', async () => {
@@ -98,12 +99,13 @@ test.describe('list field', () => {
       await appAdminPage.layoutTab.addLayoutItemDialog.selectDropdown.click();
       await appAdminPage.layoutTab.addLayoutItemDialog.getLayoutItemToCopy(field.name).click();
       await appAdminPage.layoutTab.addLayoutItemDialog.continueButton.click();
+      await appAdminPage.page.waitForLoadState('networkidle');
 
       const addListFieldModal = appAdminPage.layoutTab.getLayoutItemModal('List');
 
       await expect(addListFieldModal.generalTab.fieldInput).toHaveValue(copiedFieldName);
 
-      await addListFieldModal.saveButton.click();
+      await addListFieldModal.save();
     });
 
     await test.step('Verify the field was copied', async () => {
@@ -174,12 +176,13 @@ test.describe('list field', () => {
       await appAdminPage.layoutTab.addLayoutItemDialog.selectDropdown.click();
       await appAdminPage.layoutTab.addLayoutItemDialog.getLayoutItemToCopy(field.name).click();
       await appAdminPage.layoutTab.addLayoutItemDialog.continueButton.click();
+      await appAdminPage.page.waitForLoadState('networkidle');
 
       const addListFieldModal = appAdminPage.layoutTab.layoutDesignerModal.getLayoutItemModal('List', 1);
 
       await expect(addListFieldModal.generalTab.fieldInput).toHaveValue(copiedFieldName);
 
-      await addListFieldModal.saveButton.click();
+      await addListFieldModal.save();
     });
 
     await test.step('Verify the field was copied', async () => {
@@ -358,10 +361,11 @@ test.describe('list field', () => {
       const fieldRow = appAdminPage.layoutTab.fieldsAndObjectsGrid.getByRole('row', { name: field.name });
       await fieldRow.hover();
       await fieldRow.getByTitle('Edit').click();
+      await appAdminPage.page.waitForLoadState('networkidle');
 
       const editListFieldModal = appAdminPage.layoutTab.getLayoutItemModal('List');
       await editListFieldModal.generalTab.fieldInput.fill(updatedFieldName);
-      await editListFieldModal.saveButton.click();
+      await editListFieldModal.save();
     });
 
     await test.step('Verify the field was updated', async () => {
@@ -584,11 +588,12 @@ test.describe('list field', () => {
       const fieldRow = appAdminPage.layoutTab.fieldsAndObjectsGrid.getByRole('row', { name: field.name });
       await fieldRow.hover();
       await fieldRow.getByTitle('Edit').click();
+      await appAdminPage.page.waitForLoadState('networkidle');
 
       const editListFieldModal = appAdminPage.layoutTab.getLayoutItemModal('List');
       await editListFieldModal.securityTabButton.click();
       await editListFieldModal.securityTab.setPermissions([]);
-      await editListFieldModal.saveButton.click();
+      await editListFieldModal.save();
     });
 
     await test.step('Navigate to created record again as test user', async () => {

--- a/tests/fields/listFormulaField.spec.ts
+++ b/tests/fields/listFormulaField.spec.ts
@@ -63,11 +63,12 @@ test.describe('list formula field', () => {
 
       await fieldRow.hover();
       await fieldRow.getByTitle('Copy').click();
+      await appAdminPage.page.waitForLoadState('networkidle');
 
       const addListFormulaFieldModal = appAdminPage.layoutTab.getLayoutItemModal('Formula');
 
       await expect(addListFormulaFieldModal.generalTab.fieldInput).toHaveValue(copiedFieldName);
-      await addListFormulaFieldModal.saveButton.click();
+      await addListFormulaFieldModal.save();
     });
 
     await test.step('Verify the field was copied', async () => {
@@ -106,12 +107,13 @@ test.describe('list formula field', () => {
       await appAdminPage.layoutTab.addLayoutItemDialog.selectDropdown.click();
       await appAdminPage.layoutTab.addLayoutItemDialog.getLayoutItemToCopy(field.name).click();
       await appAdminPage.layoutTab.addLayoutItemDialog.continueButton.click();
+      await appAdminPage.page.waitForLoadState('networkidle');
 
       const addListFormulaFieldModal = appAdminPage.layoutTab.getLayoutItemModal('Formula');
 
       await expect(addListFormulaFieldModal.generalTab.fieldInput).toHaveValue(copiedFieldName);
 
-      await addListFormulaFieldModal.saveButton.click();
+      await addListFormulaFieldModal.save();
     });
 
     await test.step('Verify the field was copied', async () => {
@@ -189,12 +191,13 @@ test.describe('list formula field', () => {
       await appAdminPage.layoutTab.addLayoutItemDialog.selectDropdown.click();
       await appAdminPage.layoutTab.addLayoutItemDialog.getLayoutItemToCopy(field.name).click();
       await appAdminPage.layoutTab.addLayoutItemDialog.continueButton.click();
+      await appAdminPage.page.waitForLoadState('networkidle');
 
       const addListFormulaFieldModal = appAdminPage.layoutTab.layoutDesignerModal.getLayoutItemModal('Formula', 1);
 
       await expect(addListFormulaFieldModal.generalTab.fieldInput).toHaveValue(copiedFieldName);
 
-      await addListFormulaFieldModal.saveButton.click();
+      await addListFormulaFieldModal.save();
     });
 
     await test.step('Verify the field was copied', async () => {
@@ -346,10 +349,11 @@ test.describe('list formula field', () => {
       const fieldRow = appAdminPage.layoutTab.fieldsAndObjectsGrid.getByRole('row', { name: field.name });
       await fieldRow.hover();
       await fieldRow.getByTitle('Edit').click();
+      await appAdminPage.page.waitForLoadState('networkidle');
 
       const editListFormulaFieldModal = appAdminPage.layoutTab.getLayoutItemModal('Formula');
       await editListFormulaFieldModal.generalTab.fieldInput.fill(updatedFieldName);
-      await editListFormulaFieldModal.saveButton.click();
+      await editListFormulaFieldModal.save();
     });
 
     await test.step('Verify the field was updated', async () => {
@@ -587,11 +591,12 @@ test.describe('list formula field', () => {
       const fieldRow = appAdminPage.layoutTab.fieldsAndObjectsGrid.getByRole('row', { name: field.name });
       await fieldRow.hover();
       await fieldRow.getByTitle('Edit').click();
+      await appAdminPage.page.waitForLoadState('networkidle');
 
       const editListFormulaFieldModal = appAdminPage.layoutTab.getLayoutItemModal('Formula');
       await editListFormulaFieldModal.securityTabButton.click();
       await editListFormulaFieldModal.securityTab.setPermissions([]);
-      await editListFormulaFieldModal.saveButton.click();
+      await editListFormulaFieldModal.save();
     });
 
     await test.step('Navigate to created record again as test user', async () => {

--- a/tests/fields/numberField.spec.ts
+++ b/tests/fields/numberField.spec.ts
@@ -51,11 +51,12 @@ test.describe('number field', () => {
 
       await fieldRow.hover();
       await fieldRow.getByTitle('Copy').click();
+      await appAdminPage.page.waitForLoadState('networkidle');
 
       const addNumberFieldModal = appAdminPage.layoutTab.getLayoutItemModal('Number');
 
       await expect(addNumberFieldModal.generalTab.fieldInput).toHaveValue(copiedFieldName);
-      await addNumberFieldModal.saveButton.click();
+      await addNumberFieldModal.save();
     });
 
     await test.step('Verify the field was copied', async () => {
@@ -89,12 +90,13 @@ test.describe('number field', () => {
       await appAdminPage.layoutTab.addLayoutItemDialog.selectDropdown.click();
       await appAdminPage.layoutTab.addLayoutItemDialog.getLayoutItemToCopy(field.name).click();
       await appAdminPage.layoutTab.addLayoutItemDialog.continueButton.click();
+      await appAdminPage.page.waitForLoadState('networkidle');
 
       const addNumberFieldModal = appAdminPage.layoutTab.getLayoutItemModal('Number');
 
       await expect(addNumberFieldModal.generalTab.fieldInput).toHaveValue(copiedFieldName);
 
-      await addNumberFieldModal.saveButton.click();
+      await addNumberFieldModal.save();
     });
 
     await test.step('Verify the field was copied', async () => {
@@ -162,12 +164,13 @@ test.describe('number field', () => {
       await appAdminPage.layoutTab.addLayoutItemDialog.selectDropdown.click();
       await appAdminPage.layoutTab.addLayoutItemDialog.getLayoutItemToCopy(field.name).click();
       await appAdminPage.layoutTab.addLayoutItemDialog.continueButton.click();
+      await appAdminPage.page.waitForLoadState('networkidle');
 
       const addNumberFieldModal = appAdminPage.layoutTab.layoutDesignerModal.getLayoutItemModal('Number', 1);
 
       await expect(addNumberFieldModal.generalTab.fieldInput).toHaveValue(copiedFieldName);
 
-      await addNumberFieldModal.saveButton.click();
+      await addNumberFieldModal.save();
     });
 
     await test.step('Verify the field was copied', async () => {
@@ -304,10 +307,11 @@ test.describe('number field', () => {
       const fieldRow = appAdminPage.layoutTab.fieldsAndObjectsGrid.getByRole('row', { name: field.name });
       await fieldRow.hover();
       await fieldRow.getByTitle('Edit').click();
+      await appAdminPage.page.waitForLoadState('networkidle');
 
       const editNumberFieldModal = appAdminPage.layoutTab.getLayoutItemModal('Number');
       await editNumberFieldModal.generalTab.fieldInput.fill(updatedFieldName);
-      await editNumberFieldModal.saveButton.click();
+      await editNumberFieldModal.save();
     });
 
     await test.step('Verify the field was updated', async () => {
@@ -554,11 +558,12 @@ test.describe('number field', () => {
       const fieldRow = appAdminPage.layoutTab.fieldsAndObjectsGrid.getByRole('row', { name: field.name });
       await fieldRow.hover();
       await fieldRow.getByTitle('Edit').click();
+      await appAdminPage.page.waitForLoadState('networkidle');
 
       const editNumberFieldModal = appAdminPage.layoutTab.getLayoutItemModal('Number');
       await editNumberFieldModal.securityTabButton.click();
       await editNumberFieldModal.securityTab.setPermissions([]);
-      await editNumberFieldModal.saveButton.click();
+      await editNumberFieldModal.save();
     });
 
     await test.step('Navigate to created record again as test user', async () => {

--- a/tests/fields/numberFormulaField.spec.ts
+++ b/tests/fields/numberFormulaField.spec.ts
@@ -57,11 +57,12 @@ test.describe('number formula field', () => {
 
       await fieldRow.hover();
       await fieldRow.getByTitle('Copy').click();
+      await appAdminPage.page.waitForLoadState('networkidle');
 
       const addNumberFormulaFieldModal = appAdminPage.layoutTab.getLayoutItemModal('Formula');
 
       await expect(addNumberFormulaFieldModal.generalTab.fieldInput).toHaveValue(copiedFieldName);
-      await addNumberFormulaFieldModal.saveButton.click();
+      await addNumberFormulaFieldModal.save();
     });
 
     await test.step('Verify the field was copied', async () => {
@@ -98,12 +99,13 @@ test.describe('number formula field', () => {
       await appAdminPage.layoutTab.addLayoutItemDialog.selectDropdown.click();
       await appAdminPage.layoutTab.addLayoutItemDialog.getLayoutItemToCopy(field.name).click();
       await appAdminPage.layoutTab.addLayoutItemDialog.continueButton.click();
+      await appAdminPage.page.waitForLoadState('networkidle');
 
       const addNumberFormulaFieldModal = appAdminPage.layoutTab.getLayoutItemModal('Formula');
 
       await expect(addNumberFormulaFieldModal.generalTab.fieldInput).toHaveValue(copiedFieldName);
 
-      await addNumberFormulaFieldModal.saveButton.click();
+      await addNumberFormulaFieldModal.save();
     });
 
     await test.step('Verify the field was copied', async () => {
@@ -177,12 +179,13 @@ test.describe('number formula field', () => {
       await appAdminPage.layoutTab.addLayoutItemDialog.selectDropdown.click();
       await appAdminPage.layoutTab.addLayoutItemDialog.getLayoutItemToCopy(field.name).click();
       await appAdminPage.layoutTab.addLayoutItemDialog.continueButton.click();
+      await appAdminPage.page.waitForLoadState('networkidle');
 
       const addNumberFormulaFieldModal = appAdminPage.layoutTab.layoutDesignerModal.getLayoutItemModal('Formula', 1);
 
       await expect(addNumberFormulaFieldModal.generalTab.fieldInput).toHaveValue(copiedFieldName);
 
-      await addNumberFormulaFieldModal.saveButton.click();
+      await addNumberFormulaFieldModal.save();
     });
 
     await test.step('Verify the field was copied', async () => {
@@ -328,10 +331,11 @@ test.describe('number formula field', () => {
       const fieldRow = appAdminPage.layoutTab.fieldsAndObjectsGrid.getByRole('row', { name: field.name });
       await fieldRow.hover();
       await fieldRow.getByTitle('Edit').click();
+      await appAdminPage.page.waitForLoadState('networkidle');
 
       const editNumberFormulaFieldModal = appAdminPage.layoutTab.getLayoutItemModal('Formula');
       await editNumberFormulaFieldModal.generalTab.fieldInput.fill(updatedFieldName);
-      await editNumberFormulaFieldModal.saveButton.click();
+      await editNumberFormulaFieldModal.save();
     });
 
     await test.step('Verify the field was updated', async () => {
@@ -563,11 +567,12 @@ test.describe('number formula field', () => {
       const fieldRow = appAdminPage.layoutTab.fieldsAndObjectsGrid.getByRole('row', { name: field.name });
       await fieldRow.hover();
       await fieldRow.getByTitle('Edit').click();
+      await appAdminPage.page.waitForLoadState('networkidle');
 
       const editTextFormulaFieldModal = appAdminPage.layoutTab.getLayoutItemModal('Formula');
       await editTextFormulaFieldModal.securityTabButton.click();
       await editTextFormulaFieldModal.securityTab.setPermissions([]);
-      await editTextFormulaFieldModal.saveButton.click();
+      await editTextFormulaFieldModal.save();
     });
 
     await test.step('Navigate to created record again as test user', async () => {

--- a/tests/fields/referenceField.spec.ts
+++ b/tests/fields/referenceField.spec.ts
@@ -118,6 +118,7 @@ test.describe('reference field', () => {
 
       await fieldRow.hover();
       await fieldRow.getByTitle('Copy').click();
+      await appAdminPage.page.waitForLoadState('networkidle');
 
       const addReferenceFieldModal = appAdminPage.layoutTab.getLayoutItemModal('Reference');
 
@@ -169,6 +170,7 @@ test.describe('reference field', () => {
       await appAdminPage.layoutTab.addLayoutItemDialog.selectDropdown.click();
       await appAdminPage.layoutTab.addLayoutItemDialog.getLayoutItemToCopy(field.name).click();
       await appAdminPage.layoutTab.addLayoutItemDialog.continueButton.click();
+      await appAdminPage.page.waitForLoadState('networkidle');
 
       const addReferenceFieldModal = appAdminPage.layoutTab.getLayoutItemModal('Reference');
 
@@ -257,6 +259,7 @@ test.describe('reference field', () => {
       await appAdminPage.layoutTab.addLayoutItemDialog.selectDropdown.click();
       await appAdminPage.layoutTab.addLayoutItemDialog.getLayoutItemToCopy(field.name).click();
       await appAdminPage.layoutTab.addLayoutItemDialog.continueButton.click();
+      await appAdminPage.page.waitForLoadState('networkidle');
 
       const addReferenceFieldModal = appAdminPage.layoutTab.layoutDesignerModal.getLayoutItemModal('Reference', 1);
 
@@ -408,6 +411,7 @@ test.describe('reference field', () => {
       const fieldRow = appAdminPage.layoutTab.fieldsAndObjectsGrid.getByRole('row', { name: field.name });
       await fieldRow.hover();
       await fieldRow.getByTitle('Edit').click();
+      await appAdminPage.page.waitForLoadState('networkidle');
 
       const editReferenceFieldModal = appAdminPage.layoutTab.getLayoutItemModal('Reference');
       await editReferenceFieldModal.generalTab.fieldInput.fill(updatedFieldName);

--- a/tests/fields/referenceField.spec.ts
+++ b/tests/fields/referenceField.spec.ts
@@ -124,7 +124,7 @@ test.describe('reference field', () => {
 
       await expect(addReferenceFieldModal.generalTab.fieldInput).toBeVisible();
       await expect(addReferenceFieldModal.generalTab.fieldInput).toHaveValue(copiedFieldName);
-      await addReferenceFieldModal.saveButton.click();
+      await addReferenceFieldModal.save();
     });
 
     await test.step('Verify the field was copied', async () => {
@@ -177,7 +177,7 @@ test.describe('reference field', () => {
       await expect(addReferenceFieldModal.generalTab.fieldInput).toBeVisible();
       await expect(addReferenceFieldModal.generalTab.fieldInput).toHaveValue(copiedFieldName);
 
-      await addReferenceFieldModal.saveButton.click();
+      await addReferenceFieldModal.save();
     });
 
     await test.step('Verify the field was copied', async () => {
@@ -266,7 +266,7 @@ test.describe('reference field', () => {
       await expect(addReferenceFieldModal.generalTab.fieldInput).toBeVisible();
       await expect(addReferenceFieldModal.generalTab.fieldInput).toHaveValue(copiedFieldName);
 
-      await addReferenceFieldModal.saveButton.click();
+      await addReferenceFieldModal.save();
     });
 
     await test.step('Verify the field was copied', async () => {
@@ -415,7 +415,7 @@ test.describe('reference field', () => {
 
       const editReferenceFieldModal = appAdminPage.layoutTab.getLayoutItemModal('Reference');
       await editReferenceFieldModal.generalTab.fieldInput.fill(updatedFieldName);
-      await editReferenceFieldModal.saveButton.click();
+      await editReferenceFieldModal.save();
     });
 
     await test.step('Verify the field was updated', async () => {
@@ -694,7 +694,7 @@ test.describe('reference field', () => {
       const editReferenceFieldModal = appAdminPage.layoutTab.getLayoutItemModal('Text');
       await editReferenceFieldModal.securityTabButton.click();
       await editReferenceFieldModal.securityTab.setPermissions([]);
-      await editReferenceFieldModal.saveButton.click();
+      await editReferenceFieldModal.save();
     });
 
     await test.step('Navigate to created record again as test user', async () => {

--- a/tests/fields/textField.spec.ts
+++ b/tests/fields/textField.spec.ts
@@ -51,11 +51,12 @@ test.describe('text field', () => {
 
       await fieldRow.hover();
       await fieldRow.getByTitle('Copy').click();
+      await appAdminPage.page.waitForLoadState('networkidle');
 
       const addTextFieldModal = appAdminPage.layoutTab.getLayoutItemModal('Text');
 
       await expect(addTextFieldModal.generalTab.fieldInput).toHaveValue(copiedFieldName);
-      await addTextFieldModal.saveButton.click();
+      await addTextFieldModal.save();
     });
 
     await test.step('Verify the field was copied', async () => {
@@ -89,12 +90,13 @@ test.describe('text field', () => {
       await appAdminPage.layoutTab.addLayoutItemDialog.selectDropdown.click();
       await appAdminPage.layoutTab.addLayoutItemDialog.getLayoutItemToCopy(field.name).click();
       await appAdminPage.layoutTab.addLayoutItemDialog.continueButton.click();
+      await appAdminPage.page.waitForLoadState('networkidle');
 
       const addTextFieldModal = appAdminPage.layoutTab.getLayoutItemModal('Text');
 
       await expect(addTextFieldModal.generalTab.fieldInput).toHaveValue(copiedFieldName);
 
-      await addTextFieldModal.saveButton.click();
+      await addTextFieldModal.save();
     });
 
     await test.step('Verify the field was copied', async () => {
@@ -162,12 +164,13 @@ test.describe('text field', () => {
       await appAdminPage.layoutTab.addLayoutItemDialog.selectDropdown.click();
       await appAdminPage.layoutTab.addLayoutItemDialog.getLayoutItemToCopy(field.name).click();
       await appAdminPage.layoutTab.addLayoutItemDialog.continueButton.click();
+      await appAdminPage.page.waitForLoadState('networkidle');
 
       const addTextFieldModal = appAdminPage.layoutTab.layoutDesignerModal.getLayoutItemModal('Text', 1);
 
       await expect(addTextFieldModal.generalTab.fieldInput).toHaveValue(copiedFieldName);
 
-      await addTextFieldModal.saveButton.click();
+      await addTextFieldModal.save();
     });
 
     await test.step('Verify the field was copied', async () => {
@@ -304,10 +307,11 @@ test.describe('text field', () => {
       const fieldRow = appAdminPage.layoutTab.fieldsAndObjectsGrid.getByRole('row', { name: field.name });
       await fieldRow.hover();
       await fieldRow.getByTitle('Edit').click();
+      await appAdminPage.page.waitForLoadState('networkidle');
 
       const editTextFieldModal = appAdminPage.layoutTab.getLayoutItemModal('Text');
       await editTextFieldModal.generalTab.fieldInput.fill(updatedFieldName);
-      await editTextFieldModal.saveButton.click();
+      await editTextFieldModal.save();
     });
 
     await test.step('Verify the field was updated', async () => {
@@ -554,11 +558,12 @@ test.describe('text field', () => {
       const fieldRow = appAdminPage.layoutTab.fieldsAndObjectsGrid.getByRole('row', { name: field.name });
       await fieldRow.hover();
       await fieldRow.getByTitle('Edit').click();
+      await appAdminPage.page.waitForLoadState('networkidle');
 
       const editTextFieldModal = appAdminPage.layoutTab.getLayoutItemModal('Text');
       await editTextFieldModal.securityTabButton.click();
       await editTextFieldModal.securityTab.setPermissions([]);
-      await editTextFieldModal.saveButton.click();
+      await editTextFieldModal.save();
     });
 
     await test.step('Navigate to created record again as test user', async () => {

--- a/tests/fields/textFormulaField.spec.ts
+++ b/tests/fields/textFormulaField.spec.ts
@@ -57,11 +57,12 @@ test.describe('text formula field', () => {
 
       await fieldRow.hover();
       await fieldRow.getByTitle('Copy').click();
+      await appAdminPage.page.waitForLoadState('networkidle');
 
       const addTextFormulaFieldModal = appAdminPage.layoutTab.getLayoutItemModal('Formula');
 
       await expect(addTextFormulaFieldModal.generalTab.fieldInput).toHaveValue(copiedFieldName);
-      await addTextFormulaFieldModal.saveButton.click();
+      await addTextFormulaFieldModal.save();
     });
 
     await test.step('Verify the field was copied', async () => {
@@ -98,12 +99,13 @@ test.describe('text formula field', () => {
       await appAdminPage.layoutTab.addLayoutItemDialog.selectDropdown.click();
       await appAdminPage.layoutTab.addLayoutItemDialog.getLayoutItemToCopy(field.name).click();
       await appAdminPage.layoutTab.addLayoutItemDialog.continueButton.click();
+      await appAdminPage.page.waitForLoadState('networkidle');
 
       const addTextFormulaFieldModal = appAdminPage.layoutTab.getLayoutItemModal('Formula');
 
       await expect(addTextFormulaFieldModal.generalTab.fieldInput).toHaveValue(copiedFieldName);
 
-      await addTextFormulaFieldModal.saveButton.click();
+      await addTextFormulaFieldModal.save();
     });
 
     await test.step('Verify the field was copied', async () => {
@@ -177,12 +179,13 @@ test.describe('text formula field', () => {
       await appAdminPage.layoutTab.addLayoutItemDialog.selectDropdown.click();
       await appAdminPage.layoutTab.addLayoutItemDialog.getLayoutItemToCopy(field.name).click();
       await appAdminPage.layoutTab.addLayoutItemDialog.continueButton.click();
+      await appAdminPage.page.waitForLoadState('networkidle');
 
       const addTextFormulaFieldModal = appAdminPage.layoutTab.layoutDesignerModal.getLayoutItemModal('Formula', 1);
 
       await expect(addTextFormulaFieldModal.generalTab.fieldInput).toHaveValue(copiedFieldName);
 
-      await addTextFormulaFieldModal.saveButton.click();
+      await addTextFormulaFieldModal.save();
     });
 
     await test.step('Verify the field was copied', async () => {
@@ -328,10 +331,11 @@ test.describe('text formula field', () => {
       const fieldRow = appAdminPage.layoutTab.fieldsAndObjectsGrid.getByRole('row', { name: field.name });
       await fieldRow.hover();
       await fieldRow.getByTitle('Edit').click();
+      await appAdminPage.page.waitForLoadState('networkidle');
 
       const editTextFormulaFieldModal = appAdminPage.layoutTab.getLayoutItemModal('Formula');
       await editTextFormulaFieldModal.generalTab.fieldInput.fill(updatedFieldName);
-      await editTextFormulaFieldModal.saveButton.click();
+      await editTextFormulaFieldModal.save();
     });
 
     await test.step('Verify the field was updated', async () => {
@@ -563,11 +567,12 @@ test.describe('text formula field', () => {
       const fieldRow = appAdminPage.layoutTab.fieldsAndObjectsGrid.getByRole('row', { name: field.name });
       await fieldRow.hover();
       await fieldRow.getByTitle('Edit').click();
+      await appAdminPage.page.waitForLoadState('networkidle');
 
       const editTextFormulaFieldModal = appAdminPage.layoutTab.getLayoutItemModal('Formula');
       await editTextFormulaFieldModal.securityTabButton.click();
       await editTextFormulaFieldModal.securityTab.setPermissions([]);
-      await editTextFormulaFieldModal.saveButton.click();
+      await editTextFormulaFieldModal.save();
     });
 
     await test.step('Navigate to created record again as test user', async () => {

--- a/tests/fields/timeSpanField.spec.ts
+++ b/tests/fields/timeSpanField.spec.ts
@@ -53,11 +53,12 @@ test.describe('time span field', () => {
 
       await fieldRow.hover();
       await fieldRow.getByTitle('Copy').click();
+      await appAdminPage.page.waitForLoadState('networkidle');
 
       const addTimeSpanFieldModal = appAdminPage.layoutTab.getLayoutItemModal('Time Span');
 
       await expect(addTimeSpanFieldModal.generalTab.fieldInput).toHaveValue(copiedFieldName);
-      await addTimeSpanFieldModal.saveButton.click();
+      await addTimeSpanFieldModal.save();
     });
 
     await test.step('Verify the field was copied', async () => {
@@ -91,12 +92,13 @@ test.describe('time span field', () => {
       await appAdminPage.layoutTab.addLayoutItemDialog.selectDropdown.click();
       await appAdminPage.layoutTab.addLayoutItemDialog.getLayoutItemToCopy(field.name).click();
       await appAdminPage.layoutTab.addLayoutItemDialog.continueButton.click();
+      await appAdminPage.page.waitForLoadState('networkidle');
 
       const addTimeSpanFieldModal = appAdminPage.layoutTab.getLayoutItemModal('Time Span');
 
       await expect(addTimeSpanFieldModal.generalTab.fieldInput).toHaveValue(copiedFieldName);
 
-      await addTimeSpanFieldModal.saveButton.click();
+      await addTimeSpanFieldModal.save();
     });
 
     await test.step('Verify the field was copied', async () => {
@@ -166,12 +168,13 @@ test.describe('time span field', () => {
       await appAdminPage.layoutTab.addLayoutItemDialog.selectDropdown.click();
       await appAdminPage.layoutTab.addLayoutItemDialog.getLayoutItemToCopy(field.name).click();
       await appAdminPage.layoutTab.addLayoutItemDialog.continueButton.click();
+      await appAdminPage.page.waitForLoadState('networkidle');
 
       const addTimeSpanFieldModal = appAdminPage.layoutTab.layoutDesignerModal.getLayoutItemModal('Time Span', 1);
 
       await expect(addTimeSpanFieldModal.generalTab.fieldInput).toHaveValue(copiedFieldName);
 
-      await addTimeSpanFieldModal.saveButton.click();
+      await addTimeSpanFieldModal.save();
     });
 
     await test.step('Verify the field was copied', async () => {
@@ -308,10 +311,11 @@ test.describe('time span field', () => {
       const fieldRow = appAdminPage.layoutTab.fieldsAndObjectsGrid.getByRole('row', { name: field.name });
       await fieldRow.hover();
       await fieldRow.getByTitle('Edit').click();
+      await appAdminPage.page.waitForLoadState('networkidle');
 
       const editTimeSpanFieldModal = appAdminPage.layoutTab.getLayoutItemModal('Time Span');
       await editTimeSpanFieldModal.generalTab.fieldInput.fill(updatedFieldName);
-      await editTimeSpanFieldModal.saveButton.click();
+      await editTimeSpanFieldModal.save();
     });
 
     await test.step('Verify the field was updated', async () => {
@@ -570,11 +574,12 @@ test.describe('time span field', () => {
       const fieldRow = appAdminPage.layoutTab.fieldsAndObjectsGrid.getByRole('row', { name: field.name });
       await fieldRow.hover();
       await fieldRow.getByTitle('Edit').click();
+      await appAdminPage.page.waitForLoadState('networkidle');
 
       const editTimeSpanFieldModal = appAdminPage.layoutTab.getLayoutItemModal('Time Span');
       await editTimeSpanFieldModal.securityTabButton.click();
       await editTimeSpanFieldModal.securityTab.setPermissions([]);
-      await editTimeSpanFieldModal.saveButton.click();
+      await editTimeSpanFieldModal.save();
     });
 
     await test.step('Navigate to created record again as test user', async () => {

--- a/tests/layoutItems/formattedTextBlock.spec.ts
+++ b/tests/layoutItems/formattedTextBlock.spec.ts
@@ -57,11 +57,12 @@ test.describe('formatted text block', () => {
 
       await textBlockRow.hover();
       await textBlockRow.getByTitle('Copy').click();
+      await appAdminPage.page.waitForLoadState('networkidle');
 
       const addTextBlockModal = appAdminPage.layoutTab.getLayoutItemModal('Formatted Text Block');
 
       await expect(addTextBlockModal.generalTab.nameInput).toHaveValue(copiedTextBlockName);
-      await addTextBlockModal.saveButton.click();
+      await addTextBlockModal.save();
     });
 
     await test.step('Verify the text block was copied', async () => {
@@ -98,12 +99,13 @@ test.describe('formatted text block', () => {
       await appAdminPage.layoutTab.addLayoutItemDialog.selectDropdown.click();
       await appAdminPage.layoutTab.addLayoutItemDialog.getLayoutItemToCopy(textBlock.name).click();
       await appAdminPage.layoutTab.addLayoutItemDialog.continueButton.click();
+      await appAdminPage.page.waitForLoadState('networkidle');
 
       const addTextBlockModal = appAdminPage.layoutTab.getLayoutItemModal('Formatted Text Block');
 
       await expect(addTextBlockModal.generalTab.nameInput).toHaveValue(copiedTextBlockName);
 
-      await addTextBlockModal.saveButton.click();
+      await addTextBlockModal.save();
     });
 
     await test.step('Verify the text block was copied', async () => {
@@ -178,6 +180,7 @@ test.describe('formatted text block', () => {
       await appAdminPage.layoutTab.addLayoutItemDialog.selectDropdown.click();
       await appAdminPage.layoutTab.addLayoutItemDialog.getLayoutItemToCopy(textBlock.name).click();
       await appAdminPage.layoutTab.addLayoutItemDialog.continueButton.click();
+      await appAdminPage.page.waitForLoadState('networkidle');
 
       const addTextBlockModal = appAdminPage.layoutTab.layoutDesignerModal.getLayoutItemModal(
         'Formatted Text Block',
@@ -186,7 +189,7 @@ test.describe('formatted text block', () => {
 
       await expect(addTextBlockModal.generalTab.nameInput).toHaveValue(copiedTextBlockName);
 
-      await addTextBlockModal.saveButton.click();
+      await addTextBlockModal.save();
     });
 
     await test.step('Verify the text block was copied', async () => {
@@ -334,10 +337,11 @@ test.describe('formatted text block', () => {
       const textBlockRow = appAdminPage.layoutTab.fieldsAndObjectsGrid.getByRole('row', { name: textBlock.name });
       await textBlockRow.hover();
       await textBlockRow.getByTitle('Edit').click();
+      await appAdminPage.page.waitForLoadState('networkidle');
 
       const editTextBlockModal = appAdminPage.layoutTab.getLayoutItemModal('Formatted Text Block');
       await editTextBlockModal.generalTab.nameInput.fill(updatedTextBlockName);
-      await editTextBlockModal.saveButton.click();
+      await editTextBlockModal.save();
     });
 
     await test.step('Verify the text block was updated', async () => {
@@ -567,11 +571,12 @@ test.describe('formatted text block', () => {
       const textBlockRow = appAdminPage.layoutTab.fieldsAndObjectsGrid.getByRole('row', { name: textBlock.name });
       await textBlockRow.hover();
       await textBlockRow.getByTitle('Edit').click();
+      await appAdminPage.page.waitForLoadState('networkidle');
 
       const editTextBlockModal = appAdminPage.layoutTab.getLayoutItemModal('Formatted Text Block');
       await editTextBlockModal.securityTabButton.click();
       await editTextBlockModal.securityTab.setPermissions([]);
-      await editTextBlockModal.saveButton.click();
+      await editTextBlockModal.save();
     });
 
     await test.step('Navigate to created record again as test user', async () => {


### PR DESCRIPTION
- fix: wait for display fields response after selecting related app
- fix: wait for idle network after clicking continue
- fix: wait for idle after initiating edit or copy of ref field
- fix: abstract saving of item modal and wait for idle when opening item modal

closes #54 
closes #55 
