### PR TITLE
fix: addresses reference fields being saved without any grid fields

### DIFF
--- a/componentObjectModels/tabs/referenceFieldGeneralTab.ts
+++ b/componentObjectModels/tabs/referenceFieldGeneralTab.ts
@@ -17,9 +17,25 @@ export class ReferenceFieldGeneralTab extends FieldGeneralTab {
   }
 
   async selectReference(reference: string) {
-    const displayFieldResponse = this.referenceSelect.page().waitForResponse(this.referenceDisplayFieldsPathRegex);
-
+    // This is convoluted because every time the
+    // the reference is changed, the display fields are fetched
+    // however the first time the reference is clicked it
+    // automatically selects the first option and fetches the display fields
+    // its possible then that the reference we want to select
+    // is already selected and we don't need to wait for the display fields
+    // a second time hence the early return.
+    const initialDisplayFieldResponse = this.referenceSelect
+      .page()
+      .waitForResponse(this.referenceDisplayFieldsPathRegex);
     await this.referenceSelect.click();
+    await initialDisplayFieldResponse;
+
+    const referenceSelectText = await this.referenceSelect.innerText();
+
+    if (referenceSelectText.includes(reference)) {
+      return await this.frame.getByRole('option', { name: reference }).click();
+    }
+    const displayFieldResponse = this.referenceSelect.page().waitForResponse(this.referenceDisplayFieldsPathRegex);
     await this.frame.getByRole('option', { name: reference }).click();
     await displayFieldResponse;
   }

--- a/fixtures/app.fixtures.ts
+++ b/fixtures/app.fixtures.ts
@@ -11,13 +11,11 @@ export async function appAdminPage({ sysAdminPage }: { sysAdminPage: Page }, use
 }
 
 export async function app({ sysAdminPage }: { sysAdminPage: Page }, use: (r: App) => Promise<void>) {
-  const appsAdminPage = new AppsAdminPage(sysAdminPage);
-
   const app = await createApp(sysAdminPage);
 
   await use(app);
 
-  await appsAdminPage.deleteApps([app.name]);
+  await new AppsAdminPage(sysAdminPage).deleteApps([app.name]);
 }
 
 export async function createApp(sysAdminPage: Page) {

--- a/fixtures/auth.fixtures.ts
+++ b/fixtures/auth.fixtures.ts
@@ -74,16 +74,17 @@ export async function createBaseAuthPage(
 export function errorResponseHandler(response: Response) {
   const url = response.url();
   const isBaseUrl = url.includes(BASE_URL);
+  const timestamp = new Date().toISOString();
 
   if (isBaseUrl && response.status() === 524) {
-    throw new Error(`Request to ${url} timed out.`);
+    throw new Error(`Request to ${url} timed out at ${timestamp}.`);
   }
 
   if (isBaseUrl && response.status() === 520) {
-    throw new Error(`Request to ${url} returned an unexpected response.`);
+    throw new Error(`Request to ${url} returned an unexpected response at ${timestamp}.`);
   }
 
   if (isBaseUrl && response.status() === 502) {
-    throw new Error(`Request to ${url} encountered a bad gateway.`);
+    throw new Error(`Request to ${url} encountered a bad gateway at ${timestamp}.`);
   }
 }

--- a/pageObjectModels/apps/appsAdminPage.ts
+++ b/pageObjectModels/apps/appsAdminPage.ts
@@ -45,6 +45,20 @@ export class AppsAdminPage extends BaseAdminPage {
   async deleteAllTestApps() {
     await this.goto();
 
+    const scrollableElement = this.appGrid.locator('.k-grid-content.k-auto-scrollable').first();
+
+    const pager = this.appGrid.locator('.k-pager-info').first();
+    const pagerText = await pager.innerText();
+    const totalNumOfApps = parseInt(pagerText.trim().split(' ')[0]);
+    const appRows = this.appGrid.getByRole('row');
+    let appRowsCount = await appRows.count();
+
+    while (appRowsCount < totalNumOfApps) {
+      await scrollableElement.evaluate(el => (el.scrollTop = el.scrollHeight));
+      await this.page.waitForLoadState('networkidle');
+      appRowsCount = await appRows.count();
+    }
+
     const appRow = this.appGrid.getByRole('row', { name: new RegExp(TEST_APP_NAME, 'i') }).last();
     let isVisible = await appRow.isVisible();
 

--- a/pageObjectModels/containers/containersAdminPage.ts
+++ b/pageObjectModels/containers/containersAdminPage.ts
@@ -17,7 +17,7 @@ export class ContainersAdminPage extends BaseAdminPage {
     this.getListPagePath = '/Admin/Dashboard/Container/GetListPage';
     this.deleteContainerPathRegex = /\/Admin\/Dashboard\/Container\/\d+\/Delete/;
     this.createContainerButton = page.getByRole('button', { name: 'Create Container' });
-    this.containerGrid = page.getByRole('grid');
+    this.containerGrid = page.locator('#grid');
     this.deleteContainerDialog = new DeleteContainerDialog(page);
   }
 
@@ -30,6 +30,23 @@ export class ContainersAdminPage extends BaseAdminPage {
 
   async deleteAllTestContainers() {
     await this.goto();
+
+    const scrollableElement = this.containerGrid.locator('.k-grid-content.k-auto-scrollable').first();
+
+    const pager = this.containerGrid.locator('.k-pager-info').first();
+    const pagerText = await pager.innerText();
+    const totalNumOfContainers = parseInt(pagerText.trim().split(' ')[0]);
+
+    if (Number.isNaN(totalNumOfContainers) === false) {
+      const containerRows = this.containerGrid.getByRole('row');
+      let containerRowsCount = await containerRows.count();
+
+      while (containerRowsCount < totalNumOfContainers) {
+        await scrollableElement.evaluate(el => (el.scrollTop = el.scrollHeight));
+        await this.page.waitForLoadState('networkidle');
+        containerRowsCount = await containerRows.count();
+      }
+    }
 
     const containerRow = this.containerGrid.getByRole('row', { name: new RegExp(TEST_CONTAINER_NAME, 'i') }).last();
 

--- a/pageObjectModels/dataImports/dataImportsAdminPage.ts
+++ b/pageObjectModels/dataImports/dataImportsAdminPage.ts
@@ -29,9 +29,27 @@ export class DataImportsAdminPage extends BaseAdminPage {
   async deleteAllTestImports() {
     await this.goto();
 
+    const scrollableElement = this.dataImportGrid.locator('.k-grid-content.k-auto-scrollable').first();
+
+    const pager = this.dataImportGrid.locator('.k-pager-info').first();
+    const pagerText = await pager.innerText();
+    const totalNumOfImports = parseInt(pagerText.trim().split(' ')[0]);
+
+    if (Number.isNaN(totalNumOfImports) === false) {
+      const importRows = this.dataImportGrid.getByRole('row');
+      let importRowsCount = await importRows.count();
+
+      while (importRowsCount < totalNumOfImports) {
+        await scrollableElement.evaluate(el => (el.scrollTop = el.scrollHeight));
+        await this.page.waitForLoadState('networkidle');
+        importRowsCount = await importRows.count();
+      }
+    }
+
     const deleteImportRow = this.dataImportGrid
       .getByRole('row', { name: new RegExp(TEST_DATA_IMPORT_NAME, 'i') })
       .last();
+
     let isVisible = await deleteImportRow.isVisible();
 
     while (isVisible) {

--- a/pageObjectModels/users/usersSecurityAdminPage.ts
+++ b/pageObjectModels/users/usersSecurityAdminPage.ts
@@ -29,6 +29,23 @@ export class UsersSecurityAdminPage extends BaseAdminPage {
   async deleteAllTestUsers() {
     await this.goto();
 
+    const scrollableElement = this.userGrid.locator('.k-grid-content.k-auto-scrollable').first();
+
+    const pager = this.userGrid.locator('.k-pager-info').first();
+    const pagerText = await pager.innerText();
+    const totalNumOfUsers = parseInt(pagerText.trim().split(' ')[0]);
+
+    if (Number.isNaN(totalNumOfUsers) === false) {
+      const userRows = this.userGrid.getByRole('row');
+      let userRowsCount = await userRows.count();
+
+      while (userRowsCount < totalNumOfUsers) {
+        await scrollableElement.evaluate(el => (el.scrollTop = el.scrollHeight));
+        await this.page.waitForLoadState('networkidle');
+        userRowsCount = await userRows.count();
+      }
+    }
+
     const userRow = this.userGrid.getByRole('row', { name: new RegExp(TEST_USER_NAME, 'i') }).last();
     let isVisible = await userRow.isVisible();
 


### PR DESCRIPTION
Added conditional logic to selecting the reference for a reference field to account for the situations where only one request is made to fetch the display fields or two requests are made to display fields. depending on whether the reference that is automatically selected on the initial click is actually the reference we want or not.