### PR TITLE
feat: add tests for dynamic documents

### DIFF
--- a/componentObjectModels/dialogs/addReportDialog.ts
+++ b/componentObjectModels/dialogs/addReportDialog.ts
@@ -1,0 +1,78 @@
+import { Locator, Page } from '@playwright/test';
+import { Report, SavedReport, TempReport } from '../../models/report';
+
+type SchedulingStatus = 'Enabled' | 'Disabled';
+type Security = 'Private to me' | 'Private by Role' | 'Public';
+
+export class AddReportDialog {
+  private blankReportRadioButton: Locator;
+  private copyReportRadioButton: Locator;
+  private reportToCopySelector: Locator;
+  private tempReportRadioButton: Locator;
+  private savedReportRadioButton: Locator;
+  private reportNameInput: Locator;
+  private schedulingSelector: Locator;
+  private securitySelector: Locator;
+  private readonly saveButton: Locator;
+
+  constructor(page: Page) {
+    this.blankReportRadioButton = page.getByRole('radio', { name: 'A blank report' });
+    this.copyReportRadioButton = page.getByRole('radio', { name: 'A copy of' });
+    this.reportToCopySelector = page.getByText(/select a report/i);
+    this.tempReportRadioButton = page.getByRole('radio', { name: 'Add as a temporary report (can be saved later)' });
+    this.savedReportRadioButton = page.getByRole('radio', { name: 'Create as a saved report' });
+    this.reportNameInput = page.getByPlaceholder('Report Name');
+    this.schedulingSelector = page.locator('.label:has-text("Scheduling") + .data').getByRole('listbox');
+    this.securitySelector = page.locator('.label:has-text("Security") + .data').getByRole('listbox');
+    this.saveButton = page.getByRole('button', { name: 'Save' });
+  }
+
+  private async selectScheduling(scheduling: SchedulingStatus) {
+    await this.schedulingSelector.click();
+    await this.schedulingSelector.page().getByRole('option', { name: scheduling }).click();
+  }
+
+  private async selectReportToCopy(reportToCopy: string) {
+    await this.reportToCopySelector.click();
+    await this.reportToCopySelector.page().getByText(reportToCopy).click();
+  }
+
+  private async selectSecurity(security: Security) {
+    await this.securitySelector.click();
+    await this.securitySelector.page().getByRole('option', { name: security }).click();
+  }
+
+  async addReport(report: Report) {
+    await this.blankReportRadioButton.click();
+
+    if (report instanceof TempReport) {
+      await this.tempReportRadioButton.click();
+    }
+
+    if (report instanceof SavedReport) {
+      await this.savedReportRadioButton.click();
+      await this.reportNameInput.fill(report.name);
+      await this.selectSecurity(report.security);
+    }
+
+    await this.saveButton.click();
+  }
+
+  async addReportCopy(reportToCopy: string, report: Report) {
+    await this.copyReportRadioButton.click();
+    await this.selectReportToCopy(reportToCopy);
+
+    if (report instanceof TempReport) {
+      await this.tempReportRadioButton.click();
+    }
+
+    if (report instanceof SavedReport) {
+      await this.savedReportRadioButton.click();
+      await this.reportNameInput.fill(report.name);
+      await this.selectScheduling(report.scheduling);
+      await this.selectSecurity(report.security);
+    }
+
+    await this.saveButton.click();
+  }
+}

--- a/componentObjectModels/dialogs/createDocumentDialog.ts
+++ b/componentObjectModels/dialogs/createDocumentDialog.ts
@@ -1,8 +1,0 @@
-import { Page } from '@playwright/test';
-import { BaseCreateOrAddDialogWithSaveButton } from './baseCreateOrAddDialog';
-
-export class CreateDocumentDialog extends BaseCreateOrAddDialogWithSaveButton {
-  constructor(page: Page) {
-    super(page);
-  }
-}

--- a/componentObjectModels/dialogs/createDynamicDocumentDialog.ts
+++ b/componentObjectModels/dialogs/createDynamicDocumentDialog.ts
@@ -1,17 +1,17 @@
 import { Locator, Page } from '@playwright/test';
-import { BaseCreateOrAddDialogWithSaveButton } from '../dialogs/baseCreateOrAddDialog';
+import { BaseCreateOrAddDialogWithSaveButton } from './baseCreateOrAddDialog';
 
-export class CreateTextMessageDialog extends BaseCreateOrAddDialogWithSaveButton {
+export class CreateDynamicDocumentDialog extends BaseCreateOrAddDialogWithSaveButton {
   constructor(page: Page) {
     super(page);
   }
 
-  getTextToCopy(textName: string) {
-    return this.getItemToCopy(textName);
+  getDocumentToCopy(documentName: string) {
+    return this.getItemToCopy(documentName);
   }
 }
 
-export class CreateTextMessageDialogForApp extends CreateTextMessageDialog {
+export class CreateDynamicDocumentDialogForApp extends CreateDynamicDocumentDialog {
   private readonly appSelect: Locator;
 
   constructor(page: Page) {

--- a/componentObjectModels/dialogs/createTextMessageDialog.ts
+++ b/componentObjectModels/dialogs/createTextMessageDialog.ts
@@ -1,0 +1,26 @@
+import { Locator, Page } from '@playwright/test';
+import { BaseCreateOrAddDialogWithSaveButton } from './baseCreateOrAddDialog';
+
+export class CreateTextMessageDialog extends BaseCreateOrAddDialogWithSaveButton {
+  constructor(page: Page) {
+    super(page);
+  }
+
+  getTextToCopy(textName: string) {
+    return this.getItemToCopy(textName);
+  }
+}
+
+export class CreateTextMessageDialogForApp extends CreateTextMessageDialog {
+  private readonly appSelect: Locator;
+
+  constructor(page: Page) {
+    super(page);
+    this.appSelect = this.page.getByRole('listbox', { name: 'App/Survey' });
+  }
+
+  async selectApp(appName: string) {
+    await this.appSelect.click();
+    await this.page.getByRole('option', { name: appName }).click();
+  }
+}

--- a/componentObjectModels/dialogs/deleteDocumentDialog.ts
+++ b/componentObjectModels/dialogs/deleteDocumentDialog.ts
@@ -1,0 +1,8 @@
+import { Page } from '@playwright/test';
+import { BaseDeleteDialog } from './baseDeleteDialog';
+
+export class DeleteDocumentDialog extends BaseDeleteDialog {
+  constructor(page: Page) {
+    super(page);
+  }
+}

--- a/componentObjectModels/menus/contentRecordActionMenu.ts
+++ b/componentObjectModels/menus/contentRecordActionMenu.ts
@@ -4,6 +4,7 @@ export class ContentRecordActionMenu {
   private readonly menu: Locator;
   readonly copyRecordLink: Locator;
   readonly printRecordLink: Locator;
+  readonly generateDocumentLink: Locator;
   readonly viewVersionHistoryLink: Locator;
   readonly deleteRecordLink: Locator;
   readonly editLayoutLink: Locator;
@@ -12,6 +13,7 @@ export class ContentRecordActionMenu {
     this.menu = menu;
     this.copyRecordLink = this.menu.getByText('Copy Record');
     this.printRecordLink = this.menu.getByText('Print Record');
+    this.generateDocumentLink = this.menu.getByText('Generate Document');
     this.viewVersionHistoryLink = this.menu.getByText('View Version History');
     this.deleteRecordLink = this.menu.getByText('Delete Record');
     this.editLayoutLink = this.menu.getByText('Edit Layout');

--- a/componentObjectModels/modals/generateDynamicDocumentModal.ts
+++ b/componentObjectModels/modals/generateDynamicDocumentModal.ts
@@ -1,0 +1,66 @@
+import { Locator, Page } from '@playwright/test';
+
+type FileTypeSelection = 'PDF' | 'Microsoft Word';
+
+type DocumentActionSelection =
+  | 'Email the document to me'
+  | 'Save to an attachment field'
+  | 'Save to an attachment field and email it to me';
+
+type EmailDeliverySelection = 'Email a link to the document' | 'Attach to the email';
+
+type FillOutFormParams =
+  | {
+      fileType: FileTypeSelection;
+      documentAction: 'Email the document to me' | 'Save to an attachment field and email it to me';
+      emailDeliverySelection: EmailDeliverySelection;
+    }
+  | {
+      fileType: FileTypeSelection;
+      documentAction: 'Save to an attachment field';
+    };
+
+export class GenerateDynamicDocumentModal {
+  private readonly modal: Locator;
+  private readonly fileTypeSelector: Locator;
+  private readonly documentActionSelector: Locator;
+  private readonly emailDeliverySelector: Locator;
+  readonly okButton: Locator;
+  readonly cancelButton: Locator;
+  readonly closeButton: Locator;
+
+  constructor(page: Page) {
+    this.modal = page.getByRole('dialog', { name: /generate dynamic document/i });
+    this.fileTypeSelector = this.modal.locator('.label:has-text("File Type") + .data').getByRole('listbox');
+    this.documentActionSelector = this.modal.locator('.label:has-text("Document Action") + .data').getByRole('listbox');
+    this.emailDeliverySelector = this.modal.locator('.label:has-text("Email Delivery") + .data').getByRole('listbox');
+    this.okButton = this.modal.getByRole('button', { name: 'OK' });
+    this.cancelButton = this.modal.getByRole('button', { name: 'Cancel' });
+    this.closeButton = this.modal.getByRole('button', { name: 'Close' });
+  }
+
+  private async selectFileType(fileType: FileTypeSelection) {
+    await this.fileTypeSelector.click();
+    await this.fileTypeSelector.page().getByRole('option', { name: fileType }).click();
+  }
+
+  private async selectDocumentAction(documentAction: DocumentActionSelection) {
+    await this.documentActionSelector.click();
+    await this.documentActionSelector.page().getByRole('option', { name: documentAction, exact: true }).click();
+  }
+
+  private async selectEmailDelivery(emailDelivery: EmailDeliverySelection) {
+    await this.emailDeliverySelector.click();
+    await this.emailDeliverySelector.page().getByRole('option', { name: emailDelivery }).click();
+  }
+
+  async fillOutForm(params: FillOutFormParams) {
+    await this.selectFileType(params.fileType);
+
+    await this.selectDocumentAction(params.documentAction);
+
+    if (params.documentAction !== 'Save to an attachment field') {
+      await this.selectEmailDelivery(params.emailDeliverySelection);
+    }
+  }
+}

--- a/componentObjectModels/modals/reportDesignerModal.ts
+++ b/componentObjectModels/modals/reportDesignerModal.ts
@@ -1,0 +1,15 @@
+import { Locator, Page } from '@playwright/test';
+
+export class ReportDesignerModal {
+  private readonly modal: Locator;
+  private readonly saveAndRunButton: Locator;
+
+  constructor(page: Page) {
+    this.modal = page.getByRole('dialog', { name: /report designer/i });
+    this.saveAndRunButton = this.modal.getByRole('button', { name: 'Save Changes & Run' });
+  }
+
+  async saveChangesAndRun() {
+    await this.saveAndRunButton.click();
+  }
+}

--- a/componentObjectModels/navs/adminNav.ts
+++ b/componentObjectModels/navs/adminNav.ts
@@ -16,6 +16,7 @@ export class AdminNav {
   readonly listCreateMenuOption: Locator;
   readonly textCreateMenuOption: Locator;
   readonly sendingNumberCreateMenuOption: Locator;
+  readonly dynamicDocumentCreateMenuOption: Locator;
 
   private getMenuOption(menuOptionText: string) {
     return this.adminCreateMenu.getByText(menuOptionText);
@@ -37,5 +38,6 @@ export class AdminNav {
     this.listCreateMenuOption = this.getMenuOption('List');
     this.textCreateMenuOption = this.getMenuOption('Text Message');
     this.sendingNumberCreateMenuOption = this.getMenuOption('Sending Number');
+    this.dynamicDocumentCreateMenuOption = this.getMenuOption('Document');
   }
 }

--- a/componentObjectModels/tabs/appDocumentsTab.ts
+++ b/componentObjectModels/tabs/appDocumentsTab.ts
@@ -1,20 +1,30 @@
 import { Locator, Page } from '@playwright/test';
-import { CreateDocumentDialog } from '../dialogs/createDocumentDialog';
+import { CreateDynamicDocumentDialog } from '../dialogs/createDynamicDocumentDialog';
 
 export class AppDocumentsTab {
   private readonly addDocumentLink: Locator;
-  private readonly createDocumentDialog: CreateDocumentDialog;
+  private readonly createDocumentDialog: CreateDynamicDocumentDialog;
   readonly documentsGrid: Locator;
 
   constructor(page: Page) {
     this.addDocumentLink = page.getByRole('link', { name: 'Add Document' });
     this.documentsGrid = page.locator('#grid-documents');
-    this.createDocumentDialog = new CreateDocumentDialog(page);
+    this.createDocumentDialog = new CreateDynamicDocumentDialog(page);
   }
 
-  async addDocument(name: string) {
+  async createDocument(name: string) {
     await this.addDocumentLink.click();
 
+    await this.createDocumentDialog.nameInput.fill(name);
+    await this.createDocumentDialog.saveButton.click();
+  }
+
+  async createDocumentCopy(documentToCopy: string, name: string) {
+    await this.addDocumentLink.click();
+
+    await this.createDocumentDialog.copyFromRadioButton.click();
+    await this.createDocumentDialog.copyFromDropdown.click();
+    await this.createDocumentDialog.getDocumentToCopy(documentToCopy).click();
     await this.createDocumentDialog.nameInput.fill(name);
     await this.createDocumentDialog.saveButton.click();
   }

--- a/componentObjectModels/tabs/appDocumentsTab.ts
+++ b/componentObjectModels/tabs/appDocumentsTab.ts
@@ -1,15 +1,18 @@
 import { Locator, Page } from '@playwright/test';
 import { CreateDynamicDocumentDialog } from '../dialogs/createDynamicDocumentDialog';
+import { DeleteDocumentDialog } from '../dialogs/deleteDocumentDialog';
 
 export class AppDocumentsTab {
   private readonly addDocumentLink: Locator;
   private readonly createDocumentDialog: CreateDynamicDocumentDialog;
   readonly documentsGrid: Locator;
+  readonly deleteDocumentDialog: DeleteDocumentDialog;
 
   constructor(page: Page) {
     this.addDocumentLink = page.getByRole('link', { name: 'Add Document' });
     this.documentsGrid = page.locator('#grid-documents');
     this.createDocumentDialog = new CreateDynamicDocumentDialog(page);
+    this.deleteDocumentDialog = new DeleteDocumentDialog(page);
   }
 
   async createDocument(name: string) {

--- a/componentObjectModels/tabs/appMessagingTab.ts
+++ b/componentObjectModels/tabs/appMessagingTab.ts
@@ -1,7 +1,7 @@
 import { Locator, Page } from '@playwright/test';
 import { CreateEmailBodyDialog } from '../dialogs/createEmailBodyDialog';
+import { CreateTextMessageDialog } from '../dialogs/createTextMessageDialog';
 import { DeleteEmailBodyDialog } from '../dialogs/deleteEmailBodyDialog';
-import { CreateTextMessageDialog } from './createTextMessageDialog';
 
 export class AppMessagingTab {
   readonly addEmailBodyLink: Locator;

--- a/componentObjectModels/tabs/documentInformationTab.ts
+++ b/componentObjectModels/tabs/documentInformationTab.ts
@@ -18,7 +18,7 @@ export class DocumentInformationTab {
     this.saveFilePath = /\/Admin\/Document\/SaveDocumentFiles/;
   }
 
-  private async updateStatus(status: boolean) {
+  async updateStatus(status: boolean) {
     const checked = await this.statusSwitch.getAttribute('aria-checked');
     const expected = status ? 'true' : 'false';
 

--- a/componentObjectModels/tabs/documentInformationTab.ts
+++ b/componentObjectModels/tabs/documentInformationTab.ts
@@ -3,7 +3,7 @@ import { DynamicDocument } from '../../models/dynamicDocument';
 
 export class DocumentInformationTab {
   private readonly page: Page;
-  private readonly documentNameInput: Locator;
+  readonly documentNameInput: Locator;
   private readonly statusSwitch: Locator;
   private readonly statusToggle: Locator;
   private readonly addNewFileLink: Locator;

--- a/factories/fakeDataFactory.ts
+++ b/factories/fakeDataFactory.ts
@@ -21,6 +21,11 @@ export class FakeDataFactory {
     return `${timestamp}-${id}`;
   }
 
+  static createFakeReportName(): string {
+    const uniqueId = this.createUniqueIdentifier();
+    return `${uniqueId}-report-test`;
+  }
+
   static createFakeSendingNumberName(): string {
     const uniqueId = this.createUniqueIdentifier();
     return `${uniqueId}-${TEST_SENDING_NUMBER_NAME}`;

--- a/models/report.ts
+++ b/models/report.ts
@@ -1,0 +1,33 @@
+// eslint-disable-next-line @typescript-eslint/ban-types
+type ReportObject = {};
+type ReportSchedulingStatus = 'Enabled' | 'Disabled';
+type ReportSecurity = 'Private to me' | 'Private by Role' | 'Public';
+
+export abstract class Report {
+  constructor({}: ReportObject) {}
+}
+
+export class TempReport extends Report {
+  constructor({}: ReportObject) {
+    super({});
+  }
+}
+
+type SavedReportObject = ReportObject & {
+  name: string;
+  security?: ReportSecurity;
+  scheduling?: ReportSchedulingStatus;
+};
+
+export class SavedReport extends Report {
+  name: string;
+  security: ReportSecurity;
+  scheduling: ReportSchedulingStatus;
+
+  constructor({ name, security = 'Private to me', scheduling = 'Disabled' }: SavedReportObject) {
+    super({});
+    this.name = name;
+    this.security = security;
+    this.scheduling = scheduling;
+  }
+}

--- a/pageObjectModels/adminHomePage.ts
+++ b/pageObjectModels/adminHomePage.ts
@@ -47,6 +47,8 @@ export class AdminHomePage extends BaseAdminPage {
 
   readonly createTextDialog: CreateTextMessageDialogForApp;
 
+  readonly documentTileLink: Locator;
+  readonly documentTileCreateButton: Locator;
   readonly createDocumentDialog: CreateDynamicDocumentDialogForApp;
 
   private getTileLink(tilePosition: number) {
@@ -100,11 +102,23 @@ export class AdminHomePage extends BaseAdminPage {
 
     this.createTextDialog = new CreateTextMessageDialogForApp(page);
 
+    this.documentTileLink = this.getTileLink(9);
+    this.documentTileCreateButton = this.getTileCreateButton('Documents');
     this.createDocumentDialog = new CreateDynamicDocumentDialogForApp(page);
   }
 
   async goto() {
     await this.page.goto(this.path);
+  }
+
+  async createDynamicDocumentUsingDocumentTileButton(appName: string, documentName: string) {
+    await this.documentTileLink.hover();
+    await this.documentTileCreateButton.waitFor();
+    await this.documentTileCreateButton.click();
+
+    await this.createDocumentDialog.selectApp(appName);
+    await this.createDocumentDialog.nameInput.fill(documentName);
+    await this.createDocumentDialog.saveButton.click();
   }
 
   async createDynamicDocumentUsingHeaderCreateButton(appName: string, documentName: string) {

--- a/pageObjectModels/adminHomePage.ts
+++ b/pageObjectModels/adminHomePage.ts
@@ -111,6 +111,23 @@ export class AdminHomePage extends BaseAdminPage {
     await this.page.goto(this.path);
   }
 
+  async createDynamicDocumentCopyUsingDocumentTileButton(
+    appName: string,
+    documentToCopy: string,
+    documentName: string
+  ) {
+    await this.documentTileLink.hover();
+    await this.documentTileCreateButton.waitFor();
+    await this.documentTileCreateButton.click();
+
+    await this.createDocumentDialog.selectApp(appName);
+    await this.createDocumentDialog.copyFromRadioButton.click();
+    await this.createDocumentDialog.copyFromDropdown.click();
+    await this.createDocumentDialog.getDocumentToCopy(documentToCopy).click();
+    await this.createDocumentDialog.nameInput.fill(documentName);
+    await this.createDocumentDialog.saveButton.click();
+  }
+
   async createDynamicDocumentUsingDocumentTileButton(appName: string, documentName: string) {
     await this.documentTileLink.hover();
     await this.documentTileCreateButton.waitFor();
@@ -118,6 +135,23 @@ export class AdminHomePage extends BaseAdminPage {
 
     await this.createDocumentDialog.selectApp(appName);
     await this.createDocumentDialog.nameInput.fill(documentName);
+    await this.createDocumentDialog.saveButton.click();
+  }
+
+  async createDynamicDocumentCopyUsingHeaderCreateButton(
+    appName: string,
+    documentToCopyName: string,
+    documentCopyName: string
+  ) {
+    await this.adminNav.adminCreateButton.hover();
+    await this.adminNav.adminCreateMenu.waitFor();
+    await this.adminNav.dynamicDocumentCreateMenuOption.click();
+
+    await this.createDocumentDialog.selectApp(appName);
+    await this.createDocumentDialog.copyFromRadioButton.click();
+    await this.createDocumentDialog.copyFromDropdown.click();
+    await this.createDocumentDialog.getDocumentToCopy(documentToCopyName).click();
+    await this.createDocumentDialog.nameInput.fill(documentCopyName);
     await this.createDocumentDialog.saveButton.click();
   }
 

--- a/pageObjectModels/adminHomePage.ts
+++ b/pageObjectModels/adminHomePage.ts
@@ -1,12 +1,13 @@
 import { Locator, Page } from '@playwright/test';
 import { CreateApiKeyDialog } from '../componentObjectModels/dialogs/createApiKeyDialog';
 import { CreateAppDialog } from '../componentObjectModels/dialogs/createAppDialog';
+import { CreateDynamicDocumentDialogForApp } from '../componentObjectModels/dialogs/createDynamicDocumentDialog';
 import { CreateEmailBodyDialogForApp } from '../componentObjectModels/dialogs/createEmailBodyDialog';
 import { CreateImportConfigDialog } from '../componentObjectModels/dialogs/createImportConfigDialog';
 import { CreateSurveyDialog } from '../componentObjectModels/dialogs/createSurveyDialog';
+import { CreateTextMessageDialogForApp } from '../componentObjectModels/dialogs/createTextMessageDialog';
 import { CreateAppModal } from '../componentObjectModels/modals/createAppModal';
 import { CreateSurveyModal } from '../componentObjectModels/modals/createSurveyModal';
-import { CreateTextMessageDialogForApp } from '../componentObjectModels/tabs/createTextMessageDialog';
 import { CreateListDialog } from './../componentObjectModels/dialogs/createListDialog';
 import { BaseAdminPage } from './baseAdminPage';
 
@@ -45,6 +46,8 @@ export class AdminHomePage extends BaseAdminPage {
   readonly createListDialog: CreateListDialog;
 
   readonly createTextDialog: CreateTextMessageDialogForApp;
+
+  readonly createDocumentDialog: CreateDynamicDocumentDialogForApp;
 
   private getTileLink(tilePosition: number) {
     return this.page.locator(
@@ -96,10 +99,22 @@ export class AdminHomePage extends BaseAdminPage {
     this.createListDialog = new CreateListDialog(page);
 
     this.createTextDialog = new CreateTextMessageDialogForApp(page);
+
+    this.createDocumentDialog = new CreateDynamicDocumentDialogForApp(page);
   }
 
   async goto() {
     await this.page.goto(this.path);
+  }
+
+  async createDynamicDocumentUsingHeaderCreateButton(appName: string, documentName: string) {
+    await this.adminNav.adminCreateButton.hover();
+    await this.adminNav.adminCreateMenu.waitFor();
+    await this.adminNav.dynamicDocumentCreateMenuOption.click();
+
+    await this.createDocumentDialog.selectApp(appName);
+    await this.createDocumentDialog.nameInput.fill(documentName);
+    await this.createDocumentDialog.saveButton.click();
   }
 
   async createTextCopyUsingHeaderCreateButton(appName: string, textToCopyName: string, textCopyName: string) {

--- a/pageObjectModels/content/baseContentPage.ts
+++ b/pageObjectModels/content/baseContentPage.ts
@@ -1,11 +1,24 @@
 import { Locator, Page } from '@playwright/test';
+import { DeleteRecordDialog } from '../../componentObjectModels/dialogs/deleteRecordDialog';
+import { ContentRecordActionMenu } from '../../componentObjectModels/menus/contentRecordActionMenu';
+import { PrintContentRecordModal } from '../../componentObjectModels/modals/printContentRecordModal';
 import { BaseFormPage } from '../baseFormPage';
 
 export class BaseContentPage extends BaseFormPage {
   protected readonly contentContainer: Locator;
+  readonly pinRecordButton: Locator;
+  readonly actionMenuButton: Locator;
+  readonly actionMenu: ContentRecordActionMenu;
+  readonly deleteRecordDialog: DeleteRecordDialog;
+  readonly printRecordModal: PrintContentRecordModal;
 
   protected constructor(page: Page) {
     super(page);
     this.contentContainer = this.page.locator('div.contentContainer').first();
+    this.pinRecordButton = page.getByTitle('Pin Record', { exact: true });
+    this.actionMenuButton = page.locator('#action-menu-button');
+    this.actionMenu = new ContentRecordActionMenu(page.locator('#action-menu'));
+    this.deleteRecordDialog = new DeleteRecordDialog(page);
+    this.printRecordModal = new PrintContentRecordModal(page);
   }
 }

--- a/pageObjectModels/content/baseContentPage.ts
+++ b/pageObjectModels/content/baseContentPage.ts
@@ -1,6 +1,7 @@
 import { Locator, Page } from '@playwright/test';
 import { DeleteRecordDialog } from '../../componentObjectModels/dialogs/deleteRecordDialog';
 import { ContentRecordActionMenu } from '../../componentObjectModels/menus/contentRecordActionMenu';
+import { GenerateDynamicDocumentModal } from '../../componentObjectModels/modals/generateDynamicDocumentModal';
 import { PrintContentRecordModal } from '../../componentObjectModels/modals/printContentRecordModal';
 import { BaseFormPage } from '../baseFormPage';
 
@@ -11,6 +12,7 @@ export class BaseContentPage extends BaseFormPage {
   readonly actionMenu: ContentRecordActionMenu;
   readonly deleteRecordDialog: DeleteRecordDialog;
   readonly printRecordModal: PrintContentRecordModal;
+  readonly generateDocumentModal: GenerateDynamicDocumentModal;
 
   protected constructor(page: Page) {
     super(page);
@@ -20,5 +22,6 @@ export class BaseContentPage extends BaseFormPage {
     this.actionMenu = new ContentRecordActionMenu(page.locator('#action-menu'));
     this.deleteRecordDialog = new DeleteRecordDialog(page);
     this.printRecordModal = new PrintContentRecordModal(page);
+    this.generateDocumentModal = new GenerateDynamicDocumentModal(page);
   }
 }

--- a/pageObjectModels/content/editContentPage.ts
+++ b/pageObjectModels/content/editContentPage.ts
@@ -1,28 +1,15 @@
 import { Locator, Page } from '@playwright/test';
-import { DeleteRecordDialog } from '../../componentObjectModels/dialogs/deleteRecordDialog';
-import { ContentRecordActionMenu } from '../../componentObjectModels/menus/contentRecordActionMenu';
-import { PrintContentRecordModal } from '../../componentObjectModels/modals/printContentRecordModal';
 import { BASE_URL } from '../../playwright.config';
 import { EditableContentPage } from './editableContentPage';
 
 export class EditContentPage extends EditableContentPage {
   readonly pathRegex: RegExp;
-  readonly pinRecordButton: Locator;
-  readonly actionMenuButton: Locator;
-  readonly actionMenu: ContentRecordActionMenu;
   readonly viewRecordButton: Locator;
-  readonly deleteRecordDialog: DeleteRecordDialog;
-  readonly printRecordModal: PrintContentRecordModal;
 
   constructor(page: Page) {
     super(page);
     this.pathRegex = new RegExp(`${BASE_URL}/Content/[0-9]+/[0-9]+/Edit`);
-    this.pinRecordButton = page.getByTitle('Pin Record', { exact: true });
-    this.actionMenuButton = page.locator('#action-menu-button');
-    this.actionMenu = new ContentRecordActionMenu(page.locator('#action-menu'));
     this.viewRecordButton = page.getByRole('link', { name: 'View Record' });
-    this.deleteRecordDialog = new DeleteRecordDialog(page);
-    this.printRecordModal = new PrintContentRecordModal(page);
   }
 
   async goto(appId: number, recordId: number) {

--- a/pageObjectModels/documents/documentAdminPage.ts
+++ b/pageObjectModels/documents/documentAdminPage.ts
@@ -26,4 +26,14 @@ export class DocumentAdminPage extends BaseAdminPage {
     await this.createDocumentDialog.nameInput.fill(documentName);
     await this.createDocumentDialog.saveButton.click();
   }
+
+  async createDocumentCopy(appName: string, documentToCopy: string, documentName: string) {
+    await this.createDocumentButton.click();
+    await this.createDocumentDialog.selectApp(appName);
+    await this.createDocumentDialog.copyFromRadioButton.click();
+    await this.createDocumentDialog.copyFromDropdown.click();
+    await this.createDocumentDialog.getDocumentToCopy(documentToCopy).click();
+    await this.createDocumentDialog.nameInput.fill(documentName);
+    await this.createDocumentDialog.saveButton.click();
+  }
 }

--- a/pageObjectModels/documents/documentAdminPage.ts
+++ b/pageObjectModels/documents/documentAdminPage.ts
@@ -1,12 +1,14 @@
 import { Locator, Page } from '@playwright/test';
 import { CreateDynamicDocumentDialogForApp } from '../../componentObjectModels/dialogs/createDynamicDocumentDialog';
 import { BaseAdminPage } from '../baseAdminPage';
+import { DeleteDocumentDialog } from '../../componentObjectModels/dialogs/deleteDocumentDialog';
 
 export class DocumentAdminPage extends BaseAdminPage {
   readonly path: string;
   readonly documentsGrid: Locator;
   private readonly createDocumentButton: Locator;
   private readonly createDocumentDialog: CreateDynamicDocumentDialogForApp;
+  readonly deleteDocumentDialog: DeleteDocumentDialog;
 
   constructor(page: Page) {
     super(page);
@@ -14,6 +16,7 @@ export class DocumentAdminPage extends BaseAdminPage {
     this.documentsGrid = page.locator('#grid');
     this.createDocumentButton = page.getByRole('button', { name: 'Create Document' });
     this.createDocumentDialog = new CreateDynamicDocumentDialogForApp(page);
+    this.deleteDocumentDialog = new DeleteDocumentDialog(page);
   }
 
   async goto() {

--- a/pageObjectModels/documents/documentAdminPage.ts
+++ b/pageObjectModels/documents/documentAdminPage.ts
@@ -1,0 +1,29 @@
+import { Locator, Page } from '@playwright/test';
+import { CreateDynamicDocumentDialogForApp } from '../../componentObjectModels/dialogs/createDynamicDocumentDialog';
+import { BaseAdminPage } from '../baseAdminPage';
+
+export class DocumentAdminPage extends BaseAdminPage {
+  readonly path: string;
+  readonly documentsGrid: Locator;
+  private readonly createDocumentButton: Locator;
+  private readonly createDocumentDialog: CreateDynamicDocumentDialogForApp;
+
+  constructor(page: Page) {
+    super(page);
+    this.path = '/Admin/Document';
+    this.documentsGrid = page.locator('#grid');
+    this.createDocumentButton = page.getByRole('button', { name: 'Create Document' });
+    this.createDocumentDialog = new CreateDynamicDocumentDialogForApp(page);
+  }
+
+  async goto() {
+    await this.page.goto(this.path, { waitUntil: 'networkidle' });
+  }
+
+  async createDocument(appName: string, documentName: string) {
+    await this.createDocumentButton.click();
+    await this.createDocumentDialog.selectApp(appName);
+    await this.createDocumentDialog.nameInput.fill(documentName);
+    await this.createDocumentDialog.saveButton.click();
+  }
+}

--- a/pageObjectModels/messaging/textMessageAdminPage.ts
+++ b/pageObjectModels/messaging/textMessageAdminPage.ts
@@ -1,6 +1,6 @@
 import { Locator, Page } from '@playwright/test';
+import { CreateTextMessageDialogForApp } from '../../componentObjectModels/dialogs/createTextMessageDialog';
 import { DeleteTextMessageDialog } from '../../componentObjectModels/dialogs/deleteTextMessageDialog';
-import { CreateTextMessageDialogForApp } from '../../componentObjectModels/tabs/createTextMessageDialog';
 import { BaseAdminPage } from '../baseAdminPage';
 
 export class TextMessageAdminPage extends BaseAdminPage {

--- a/pageObjectModels/reports/reportAppPage.ts
+++ b/pageObjectModels/reports/reportAppPage.ts
@@ -1,0 +1,34 @@
+import { Locator, Page } from '@playwright/test';
+import { AddReportDialog } from '../../componentObjectModels/dialogs/addReportDialog';
+import { ReportDesignerModal } from '../../componentObjectModels/modals/reportDesignerModal';
+import { Report } from '../../models/report';
+import { BasePage } from '../basePage';
+
+export class ReportAppPage extends BasePage {
+  readonly pathRegex: RegExp;
+  private readonly createReportButton: Locator;
+  private readonly addReportDialog: AddReportDialog;
+  readonly reportDesigner: ReportDesignerModal;
+
+  constructor(page: Page) {
+    super(page);
+    this.pathRegex = /\/Report\/App\/\d+/;
+    this.createReportButton = page.getByRole('button', { name: 'Create Report' });
+    this.addReportDialog = new AddReportDialog(page);
+    this.reportDesigner = new ReportDesignerModal(page);
+  }
+
+  async goto(appId: number) {
+    await this.page.goto(`/Report/App/${appId}`, { waitUntil: 'networkidle' });
+  }
+
+  async createReport(report: Report) {
+    await this.createReportButton.click();
+    await this.addReportDialog.addReport(report);
+  }
+
+  async createCopyOfReport(reportToCopy: string, report: Report) {
+    await this.createReportButton.click();
+    await this.addReportDialog.addReportCopy(reportToCopy, report);
+  }
+}

--- a/pageObjectModels/reports/reportPage.ts
+++ b/pageObjectModels/reports/reportPage.ts
@@ -1,0 +1,26 @@
+import { Page } from '@playwright/test';
+import { BasePage } from '../basePage';
+
+export class ReportPage extends BasePage {
+  readonly pathRegex: RegExp;
+
+  constructor(page: Page) {
+    super(page);
+    this.pathRegex = /\/Report\/\d+\/Display/;
+  }
+
+  async goto(reportId: number) {
+    await this.page.goto(`/Report/${reportId}/Display`, { waitUntil: 'networkidle' });
+  }
+
+  async getReportIdFromUrl() {
+    if (this.page.url().match(this.pathRegex) === null) {
+      throw new Error('The current page is not a report display page.');
+    }
+
+    const url = this.page.url();
+    const urlParts = url.split('/');
+    const reportId = urlParts[urlParts.length - 2];
+    return parseInt(reportId);
+  }
+}

--- a/services/pdfParser.ts
+++ b/services/pdfParser.ts
@@ -3,7 +3,7 @@ import { TextItem } from 'pdfjs-dist/types/src/display/api';
 
 export class PdfParser {
   async findTextInPDF(pdfPath: string, text: string | string[]) {
-    const loadingTask = getDocument(pdfPath);
+    const loadingTask = getDocument({ url: pdfPath, verbosity: 0 });
     const pdf = await loadingTask.promise;
 
     for (let pageNum = 1; pageNum <= pdf.numPages; pageNum++) {

--- a/tests/contentRecord/contentRecord.spec.ts
+++ b/tests/contentRecord/contentRecord.spec.ts
@@ -228,7 +228,7 @@ test.describe('content record', () => {
 
     await test.step('Copy the content record', async () => {
       await editContentPage.actionMenuButton.click();
-      await editContentPage.actionMenuButton.copyRecordLink.click();
+      await editContentPage.actionMenu.copyRecordLink.click();
       await editContentPage.page.waitForURL(copyContentPage.pathRegex);
 
       await copyContentPage.saveRecordButton.click();
@@ -543,7 +543,7 @@ test.describe('content record', () => {
 
     await test.step('Delete the content record', async () => {
       await editContentPage.actionMenuButton.click();
-      await editContentPage.actionMenuButton.deleteRecordLink.click();
+      await editContentPage.actionMenu.deleteRecordLink.click();
 
       const backToOriginResponse = editContentPage.page.waitForResponse(/BackToOrigin/);
       await editContentPage.deleteRecordDialog.deleteButton.click();
@@ -577,7 +577,7 @@ test.describe('content record', () => {
 
     await test.step('Print the content record to PDF', async () => {
       await editContentPage.actionMenuButton.click();
-      await editContentPage.actionMenuButton.printRecordLink.click();
+      await editContentPage.actionMenu.printRecordLink.click();
 
       await editContentPage.printRecordModal.selectPrintAction('Print to a PDF and download');
 

--- a/tests/contentRecord/contentRecord.spec.ts
+++ b/tests/contentRecord/contentRecord.spec.ts
@@ -228,7 +228,7 @@ test.describe('content record', () => {
 
     await test.step('Copy the content record', async () => {
       await editContentPage.actionMenuButton.click();
-      await editContentPage.actionMenu.copyRecordLink.click();
+      await editContentPage.actionMenuButton.copyRecordLink.click();
       await editContentPage.page.waitForURL(copyContentPage.pathRegex);
 
       await copyContentPage.saveRecordButton.click();
@@ -543,7 +543,7 @@ test.describe('content record', () => {
 
     await test.step('Delete the content record', async () => {
       await editContentPage.actionMenuButton.click();
-      await editContentPage.actionMenu.deleteRecordLink.click();
+      await editContentPage.actionMenuButton.deleteRecordLink.click();
 
       const backToOriginResponse = editContentPage.page.waitForResponse(/BackToOrigin/);
       await editContentPage.deleteRecordDialog.deleteButton.click();
@@ -577,7 +577,7 @@ test.describe('content record', () => {
 
     await test.step('Print the content record to PDF', async () => {
       await editContentPage.actionMenuButton.click();
-      await editContentPage.actionMenu.printRecordLink.click();
+      await editContentPage.actionMenuButton.printRecordLink.click();
 
       await editContentPage.printRecordModal.selectPrintAction('Print to a PDF and download');
 

--- a/tests/dynamicDocuments/dynamicDocuments.spec.ts
+++ b/tests/dynamicDocuments/dynamicDocuments.spec.ts
@@ -130,31 +130,112 @@ test.describe('Dynamic Documents', () => {
     });
   });
 
-  test('Create a copy of a dynamic document via the create button on the header of the admin home page', async ({}) => {
+  test('Create a copy of a dynamic document via the create button on the header of the admin home page', async ({
+    app,
+    adminHomePage,
+    editDocumentPage,
+  }) => {
     test.info().annotations.push({
       type: AnnotationType.TestId,
       description: 'Test-242',
     });
 
-    expect(true).toBeTruthy();
+    const documentToCopy = FakeDataFactory.createFakeDocumentName();
+    const documentName = FakeDataFactory.createFakeDocumentName();
+
+    await test.step('Navigate to the admin home page', async () => {
+      await adminHomePage.goto();
+    });
+
+    await test.step('Create the dynamic document to copy', async () => {
+      await adminHomePage.createDynamicDocumentUsingHeaderCreateButton(app.name, documentToCopy);
+      await adminHomePage.page.waitForURL(editDocumentPage.pathRegex);
+    });
+
+    await test.step('Navigate back to the admin home page', async () => {
+      await adminHomePage.goto();
+    });
+
+    await test.step('Create a copy of the dynamic document', async () => {
+      await adminHomePage.createDynamicDocumentCopyUsingHeaderCreateButton(app.name, documentToCopy, documentName);
+      await adminHomePage.page.waitForURL(editDocumentPage.pathRegex);
+    });
+
+    await test.step('Verify the dynamic document was created', async () => {
+      await expect(editDocumentPage.informationTab.documentNameInput).toHaveValue(documentName);
+    });
   });
 
-  test('Create a copy of a dynamic document via the create button on the Documents tile on the admin home page', async ({}) => {
+  test('Create a copy of a dynamic document via the create button on the Documents tile on the admin home page', async ({
+    app,
+    adminHomePage,
+    editDocumentPage,
+  }) => {
     test.info().annotations.push({
       type: AnnotationType.TestId,
       description: 'Test-243',
     });
 
-    expect(true).toBeTruthy();
+    const documentToCopy = FakeDataFactory.createFakeDocumentName();
+    const documentName = FakeDataFactory.createFakeDocumentName();
+
+    await test.step('Navigate to the admin home page', async () => {
+      await adminHomePage.goto();
+    });
+
+    await test.step('Create the dynamic document to copy', async () => {
+      await adminHomePage.createDynamicDocumentUsingDocumentTileButton(app.name, documentToCopy);
+      await adminHomePage.page.waitForURL(editDocumentPage.pathRegex);
+    });
+
+    await test.step('Navigate back to the admin home page', async () => {
+      await adminHomePage.goto();
+    });
+
+    await test.step('Create a copy of the dynamic document', async () => {
+      await adminHomePage.createDynamicDocumentCopyUsingDocumentTileButton(app.name, documentToCopy, documentName);
+      await adminHomePage.page.waitForURL(editDocumentPage.pathRegex);
+    });
+
+    await test.step('Verify the dynamic document was created', async () => {
+      await expect(editDocumentPage.informationTab.documentNameInput).toHaveValue(documentName);
+    });
   });
 
-  test('Create a copy of a dynamic document via the "Create Document" button on the Documents admin page', async ({}) => {
+  test('Create a copy of a dynamic document via the "Create Document" button on the Documents admin page', async ({
+    app,
+    documentAdminPage,
+    editDocumentPage,
+  }) => {
     test.info().annotations.push({
       type: AnnotationType.TestId,
       description: 'Test-244',
     });
 
-    expect(true).toBeTruthy();
+    const documentToCopy = FakeDataFactory.createFakeDocumentName();
+    const documentName = FakeDataFactory.createFakeDocumentName();
+
+    await test.step('Navigate to the Documents admin page', async () => {
+      await documentAdminPage.goto();
+    });
+
+    await test.step('Create the dynamic document to copy', async () => {
+      await documentAdminPage.createDocument(app.name, documentToCopy);
+      await documentAdminPage.page.waitForURL(editDocumentPage.pathRegex);
+    });
+
+    await test.step('Navigate back to the Documents admin page', async () => {
+      await documentAdminPage.goto();
+    });
+
+    await test.step('Create a copy of the dynamic document', async () => {
+      await documentAdminPage.createDocumentCopy(app.name, documentToCopy, documentName);
+      await documentAdminPage.page.waitForURL(editDocumentPage.pathRegex);
+    });
+
+    await test.step('Verify the dynamic document was created', async () => {
+      await expect(editDocumentPage.informationTab.documentNameInput).toHaveValue(documentName);
+    });
   });
 
   test("Create a copy of a dynamic document via the Add Document button on an app's Documents tab", async ({

--- a/tests/dynamicDocuments/dynamicDocuments.spec.ts
+++ b/tests/dynamicDocuments/dynamicDocuments.spec.ts
@@ -417,22 +417,84 @@ test.describe('Dynamic Documents', () => {
     });
   });
 
-  test("Delete a dynamic document on an app from an app's Documents tab", async ({}) => {
+  test("Delete a dynamic document on an app from an app's Documents tab", async ({
+    app,
+    appAdminPage,
+    editDocumentPage,
+  }) => {
     test.info().annotations.push({
       type: AnnotationType.TestId,
       description: 'Test-247',
     });
 
-    expect(true).toBeTruthy();
+    const documentName = FakeDataFactory.createFakeDocumentName();
+    const documentRow = appAdminPage.documentsTab.documentsGrid.getByRole('row', { name: documentName });
+
+    await test.step("Navigate to the app's Documents tab", async () => {
+      await appAdminPage.goto(app.id);
+      await appAdminPage.documentsTabButton.click();
+    });
+
+    await test.step('Create the dynamic document to delete', async () => {
+      await appAdminPage.documentsTab.createDocument(documentName);
+      await appAdminPage.page.waitForURL(editDocumentPage.pathRegex);
+    });
+
+    await test.step("Navigate back to the app's Documents tab", async () => {
+      await appAdminPage.goto(app.id);
+      await appAdminPage.documentsTabButton.click();
+    });
+
+    await test.step('Delete the dynamic document', async () => {
+      await documentRow.hover();
+      await documentRow.getByTitle('Delete Document').click();
+
+      await appAdminPage.documentsTab.deleteDocumentDialog.deleteButton.click();
+      await appAdminPage.documentsTab.deleteDocumentDialog.waitForDialogToBeDismissed();
+    });
+
+    await test.step('Verify the dynamic document was deleted', async () => {
+      await expect(documentRow).not.toBeAttached();
+    });
   });
 
-  test('Delete a dynamic document from the Documents admin page', async ({}) => {
+  test('Delete a dynamic document from the Documents admin page', async ({
+    app,
+    documentAdminPage,
+    editDocumentPage,
+  }) => {
     test.info().annotations.push({
       type: AnnotationType.TestId,
       description: 'Test-248',
     });
 
-    expect(true).toBeTruthy();
+    const documentName = FakeDataFactory.createFakeDocumentName();
+    const documentRow = documentAdminPage.documentsGrid.getByRole('row', { name: documentName });
+
+    await test.step('Navigate to the Documents admin page', async () => {
+      await documentAdminPage.goto();
+    });
+
+    await test.step('Create the dynamic document to delete', async () => {
+      await documentAdminPage.createDocument(app.name, documentName);
+      await documentAdminPage.page.waitForURL(editDocumentPage.pathRegex);
+    });
+
+    await test.step('Navigate back to the Documents admin page', async () => {
+      await documentAdminPage.goto();
+    });
+
+    await test.step('Delete the dynamic document', async () => {
+      await documentRow.hover();
+      await documentRow.getByTitle('Delete Document').click();
+
+      await documentAdminPage.deleteDocumentDialog.deleteButton.click();
+      await documentAdminPage.deleteDocumentDialog.waitForDialogToBeDismissed();
+    });
+
+    await test.step('Verify the dynamic document was deleted', async () => {
+      await expect(documentRow).not.toBeAttached();
+    });
   });
 
   test("Disable a dynamic document from an app's Documents tab", async ({}) => {

--- a/tests/dynamicDocuments/dynamicDocuments.spec.ts
+++ b/tests/dynamicDocuments/dynamicDocuments.spec.ts
@@ -1,0 +1,143 @@
+import { test as base, expect } from '../../fixtures';
+import { AnnotationType } from '../annotations';
+
+type DynamicDocumentTestFixtures = {};
+
+const test = base.extend<DynamicDocumentTestFixtures>({});
+
+test.describe('Dynamic Documents', () => {
+  test('Create a dynamic document via the create button on the header of the admin home page', async ({}) => {
+    test.info().annotations.push({
+      type: AnnotationType.TestId,
+      description: 'Test-239',
+    });
+
+    expect(true).toBeTruthy();
+  });
+
+  test('Create a dynamic document via the create button on the Documents tile on the admin home page', async ({}) => {
+    test.info().annotations.push({
+      type: AnnotationType.TestId,
+      description: 'Test-240',
+    });
+
+    expect(true).toBeTruthy();
+  });
+
+  test('Create a dynamic document via the "Create Document" button on the Documents admin page', async ({}) => {
+    test.info().annotations.push({
+      type: AnnotationType.TestId,
+      description: 'Test-241',
+    });
+
+    expect(true).toBeTruthy();
+  });
+
+  test('Create a copy of a dynamic document via the create button on the header of the admin home page', async ({}) => {
+    test.info().annotations.push({
+      type: AnnotationType.TestId,
+      description: 'Test-242',
+    });
+
+    expect(true).toBeTruthy();
+  });
+
+  test('Create a copy of a dynamic document via the create button on the Documents tile on the admin home page', async ({}) => {
+    test.info().annotations.push({
+      type: AnnotationType.TestId,
+      description: 'Test-243',
+    });
+
+    expect(true).toBeTruthy();
+  });
+
+  test('Create a copy of a dynamic document via the "Create Document" button on the Documents admin page', async ({}) => {
+    test.info().annotations.push({
+      type: AnnotationType.TestId,
+      description: 'Test-244',
+    });
+
+    expect(true).toBeTruthy();
+  });
+
+  test("Update a dynamic document's configurations on an app from an app's Documents tab", async ({}) => {
+    test.info().annotations.push({
+      type: AnnotationType.TestId,
+      description: 'Test-245',
+    });
+
+    expect(true).toBeTruthy();
+  });
+
+  test("Update a dynamic document's configurations from the Documents admin page", async ({}) => {
+    test.info().annotations.push({
+      type: AnnotationType.TestId,
+      description: 'Test-246',
+    });
+
+    expect(true).toBeTruthy();
+  });
+
+  test("Delete a dynamic document on an app from an app's Documents tab", async ({}) => {
+    test.info().annotations.push({
+      type: AnnotationType.TestId,
+      description: 'Test-247',
+    });
+
+    expect(true).toBeTruthy();
+  });
+
+  test('Delete a dynamic document from the Documents admin page', async ({}) => {
+    test.info().annotations.push({
+      type: AnnotationType.TestId,
+      description: 'Test-248',
+    });
+
+    expect(true).toBeTruthy();
+  });
+
+  test("Disable a dynamic document from an app's Documents tab", async ({}) => {
+    test.info().annotations.push({
+      type: AnnotationType.TestId,
+      description: 'Test-254',
+    });
+
+    expect(true).toBeTruthy();
+  });
+
+  test('Disable a dynamic document from the Documents admin page', async ({}) => {
+    test.info().annotations.push({
+      type: AnnotationType.TestId,
+      description: 'Test-255',
+    });
+
+    expect(true).toBeTruthy();
+  });
+
+  test("Enable a dynamic document from an app's Documents tab", async ({}) => {
+    test.info().annotations.push({
+      type: AnnotationType.TestId,
+      description: 'Test-256',
+    });
+
+    expect(true).toBeTruthy();
+  });
+
+  test('Enable a dynamic document from the Documents admin page', async ({}) => {
+    test.info().annotations.push({
+      type: AnnotationType.TestId,
+      description: 'Test-257',
+    });
+
+    expect(true).toBeTruthy();
+  });
+
+  test('Add a report token to a dynamic document', async ({}) => {
+    test.info().annotations.push({
+      type: AnnotationType.TestId,
+      description: 'Test-794',
+    });
+
+    expect(true).toBeTruthy();
+  });
+});

--- a/tests/dynamicDocuments/dynamicDocuments.spec.ts
+++ b/tests/dynamicDocuments/dynamicDocuments.spec.ts
@@ -100,6 +100,15 @@ test.describe('Dynamic Documents', () => {
     });
   });
 
+  test("Create a dynamic document via the Add Document button on an app's Documents tab", async () => {
+    test.info().annotations.push({
+      type: AnnotationType.TestId,
+      description: 'Test-866',
+    });
+
+    expect(true).toBeTruthy();
+  });
+
   test('Create a copy of a dynamic document via the create button on the header of the admin home page', async ({}) => {
     test.info().annotations.push({
       type: AnnotationType.TestId,
@@ -122,6 +131,15 @@ test.describe('Dynamic Documents', () => {
     test.info().annotations.push({
       type: AnnotationType.TestId,
       description: 'Test-244',
+    });
+
+    expect(true).toBeTruthy();
+  });
+
+  test("Create a copy of a dynamic document via the Add Document button on an app's Documents tab", async () => {
+    test.info().annotations.push({
+      type: AnnotationType.TestId,
+      description: 'Test-867',
     });
 
     expect(true).toBeTruthy();

--- a/tests/dynamicDocuments/dynamicDocuments.spec.ts
+++ b/tests/dynamicDocuments/dynamicDocuments.spec.ts
@@ -45,13 +45,30 @@ test.describe('Dynamic Documents', () => {
     });
   });
 
-  test('Create a dynamic document via the create button on the Documents tile on the admin home page', async ({}) => {
+  test('Create a dynamic document via the create button on the Documents tile on the admin home page', async ({
+    app,
+    adminHomePage,
+    editDocumentPage,
+  }) => {
     test.info().annotations.push({
       type: AnnotationType.TestId,
       description: 'Test-240',
     });
 
-    expect(true).toBeTruthy();
+    const documentName = FakeDataFactory.createFakeDocumentName();
+
+    await test.step('Navigate to the admin home page', async () => {
+      await adminHomePage.goto();
+    });
+
+    await test.step('Create the dynamic document', async () => {
+      await adminHomePage.createDynamicDocumentUsingDocumentTileButton(app.name, documentName);
+      await adminHomePage.page.waitForURL(editDocumentPage.pathRegex);
+    });
+
+    await test.step('Verify the dynamic document was created', async () => {
+      await expect(editDocumentPage.informationTab.documentNameInput).toHaveValue(documentName);
+    });
   });
 
   test('Create a dynamic document via the "Create Document" button on the Documents admin page', async ({}) => {

--- a/tests/dynamicDocuments/dynamicDocuments.spec.ts
+++ b/tests/dynamicDocuments/dynamicDocuments.spec.ts
@@ -3,6 +3,7 @@ import { test as base, expect } from '../../fixtures';
 import { app } from '../../fixtures/app.fixtures';
 import { App } from '../../models/app';
 import { AdminHomePage } from '../../pageObjectModels/adminHomePage';
+import { DocumentAdminPage } from '../../pageObjectModels/documents/documentAdminPage';
 import { EditDocumentPage } from '../../pageObjectModels/documents/editDocumentPage';
 import { AnnotationType } from '../annotations';
 
@@ -10,12 +11,14 @@ type DynamicDocumentTestFixtures = {
   app: App;
   adminHomePage: AdminHomePage;
   editDocumentPage: EditDocumentPage;
+  documentAdminPage: DocumentAdminPage;
 };
 
 const test = base.extend<DynamicDocumentTestFixtures>({
   app: app,
   adminHomePage: async ({ sysAdminPage }, use) => await use(new AdminHomePage(sysAdminPage)),
   editDocumentPage: async ({ sysAdminPage }, use) => await use(new EditDocumentPage(sysAdminPage)),
+  documentAdminPage: async ({ sysAdminPage }, use) => await use(new DocumentAdminPage(sysAdminPage)),
 });
 
 test.describe('Dynamic Documents', () => {
@@ -71,13 +74,30 @@ test.describe('Dynamic Documents', () => {
     });
   });
 
-  test('Create a dynamic document via the "Create Document" button on the Documents admin page', async ({}) => {
+  test('Create a dynamic document via the "Create Document" button on the Documents admin page', async ({
+    app,
+    documentAdminPage,
+    editDocumentPage,
+  }) => {
     test.info().annotations.push({
       type: AnnotationType.TestId,
       description: 'Test-241',
     });
 
-    expect(true).toBeTruthy();
+    const documentName = FakeDataFactory.createFakeDocumentName();
+
+    await test.step('Navigate to the Documents admin page', async () => {
+      await documentAdminPage.goto();
+    });
+
+    await test.step('Create the dynamic document', async () => {
+      await documentAdminPage.createDocument(app.name, documentName);
+      await documentAdminPage.page.waitForURL(editDocumentPage.pathRegex);
+    });
+
+    await test.step('Verify the dynamic document was created', async () => {
+      await expect(editDocumentPage.informationTab.documentNameInput).toHaveValue(documentName);
+    });
   });
 
   test('Create a copy of a dynamic document via the create button on the header of the admin home page', async ({}) => {

--- a/tests/dynamicDocuments/dynamicDocuments.spec.ts
+++ b/tests/dynamicDocuments/dynamicDocuments.spec.ts
@@ -3,6 +3,7 @@ import { test as base, expect } from '../../fixtures';
 import { app } from '../../fixtures/app.fixtures';
 import { App } from '../../models/app';
 import { AdminHomePage } from '../../pageObjectModels/adminHomePage';
+import { AppAdminPage } from '../../pageObjectModels/apps/appAdminPage';
 import { DocumentAdminPage } from '../../pageObjectModels/documents/documentAdminPage';
 import { EditDocumentPage } from '../../pageObjectModels/documents/editDocumentPage';
 import { AnnotationType } from '../annotations';
@@ -12,6 +13,7 @@ type DynamicDocumentTestFixtures = {
   adminHomePage: AdminHomePage;
   editDocumentPage: EditDocumentPage;
   documentAdminPage: DocumentAdminPage;
+  appAdminPage: AppAdminPage;
 };
 
 const test = base.extend<DynamicDocumentTestFixtures>({
@@ -19,6 +21,7 @@ const test = base.extend<DynamicDocumentTestFixtures>({
   adminHomePage: async ({ sysAdminPage }, use) => await use(new AdminHomePage(sysAdminPage)),
   editDocumentPage: async ({ sysAdminPage }, use) => await use(new EditDocumentPage(sysAdminPage)),
   documentAdminPage: async ({ sysAdminPage }, use) => await use(new DocumentAdminPage(sysAdminPage)),
+  appAdminPage: async ({ sysAdminPage }, use) => await use(new AppAdminPage(sysAdminPage)),
 });
 
 test.describe('Dynamic Documents', () => {
@@ -100,13 +103,31 @@ test.describe('Dynamic Documents', () => {
     });
   });
 
-  test("Create a dynamic document via the Add Document button on an app's Documents tab", async () => {
+  test("Create a dynamic document via the Add Document button on an app's Documents tab", async ({
+    app,
+    appAdminPage,
+    editDocumentPage,
+  }) => {
     test.info().annotations.push({
       type: AnnotationType.TestId,
       description: 'Test-866',
     });
 
-    expect(true).toBeTruthy();
+    const documentName = FakeDataFactory.createFakeDocumentName();
+
+    await test.step("Navigate to the app's Documents tab", async () => {
+      await appAdminPage.goto(app.id);
+      await appAdminPage.documentsTabButton.click();
+    });
+
+    await test.step('Create the dynamic document', async () => {
+      await appAdminPage.documentsTab.addDocument(documentName);
+      await appAdminPage.page.waitForURL(editDocumentPage.pathRegex);
+    });
+
+    await test.step('Verify the dynamic document was created', async () => {
+      await expect(editDocumentPage.informationTab.documentNameInput).toHaveValue(documentName);
+    });
   });
 
   test('Create a copy of a dynamic document via the create button on the header of the admin home page', async ({}) => {

--- a/tests/dynamicDocuments/dynamicDocuments.spec.ts
+++ b/tests/dynamicDocuments/dynamicDocuments.spec.ts
@@ -121,7 +121,7 @@ test.describe('Dynamic Documents', () => {
     });
 
     await test.step('Create the dynamic document', async () => {
-      await appAdminPage.documentsTab.addDocument(documentName);
+      await appAdminPage.documentsTab.createDocument(documentName);
       await appAdminPage.page.waitForURL(editDocumentPage.pathRegex);
     });
 
@@ -157,13 +157,42 @@ test.describe('Dynamic Documents', () => {
     expect(true).toBeTruthy();
   });
 
-  test("Create a copy of a dynamic document via the Add Document button on an app's Documents tab", async () => {
+  test("Create a copy of a dynamic document via the Add Document button on an app's Documents tab", async ({
+    app,
+    appAdminPage,
+    editDocumentPage,
+  }) => {
     test.info().annotations.push({
       type: AnnotationType.TestId,
       description: 'Test-867',
     });
 
-    expect(true).toBeTruthy();
+    const documentToCopy = FakeDataFactory.createFakeDocumentName();
+    const documentName = FakeDataFactory.createFakeDocumentName();
+
+    await test.step("Navigate to the app's Documents tab", async () => {
+      await appAdminPage.goto(app.id);
+      await appAdminPage.documentsTabButton.click();
+    });
+
+    await test.step('Create the dynamic document to copy', async () => {
+      await appAdminPage.documentsTab.createDocument(documentToCopy);
+      await appAdminPage.page.waitForURL(editDocumentPage.pathRegex);
+    });
+
+    await test.step('Navigate back to the app Documents tab', async () => {
+      await appAdminPage.goto(app.id);
+      await appAdminPage.documentsTabButton.click();
+    });
+
+    await test.step('Create a copy of the dynamic document', async () => {
+      await appAdminPage.documentsTab.createDocumentCopy(documentToCopy, documentName);
+      await appAdminPage.page.waitForURL(editDocumentPage.pathRegex);
+    });
+
+    await test.step('Verify the dynamic document was created', async () => {
+      await expect(editDocumentPage.informationTab.documentNameInput).toHaveValue(documentName);
+    });
   });
 
   test("Update a dynamic document's configurations on an app from an app's Documents tab", async ({}) => {

--- a/tests/outcomes/outcomes.spec.ts
+++ b/tests/outcomes/outcomes.spec.ts
@@ -1847,7 +1847,7 @@ test.describe('Outcomes', () => {
     });
 
     await test.step('Create a dynamic document', async () => {
-      await appAdminPage.documentsTab.addDocument(document.name);
+      await appAdminPage.documentsTab.createDocument(document.name);
       await appAdminPage.page.waitForURL(editDocumentPage.pathRegex);
       await editDocumentPage.fillOutForm(document);
       await editDocumentPage.save();


### PR DESCRIPTION
closes #146

- **chore: stub out tests**
- **tests: add test for Test-239**
- **tests: add test for Test-240**
- **tests: add test for Test-241**
- **chore: add missing tests**
- **tests: add test for Test-866**
- **tests: add test for Test-867**
- **tests: add tests for Test-242, Test-243, Test-244**
- **tests: add test for Test-245**
- **tests: add test for Test-246**
- **tests: add tests for Test-247 and Test-248**
- **tests: add tests for Test-254 and Test-255**
- **fix: correct property name**
- **tests: add tests for Test-256 and Test-257**
- **tests: add test for Test-794**
