### PR TITLE
fix: scroll target field in to view

### DIFF
--- a/componentObjectModels/controls/mappingGrid.ts
+++ b/componentObjectModels/controls/mappingGrid.ts
@@ -35,6 +35,7 @@ export class MappingGrid {
         const sourceField = this.sourceFields.locator(`.draggable:has-text("${key}")`);
         const targetField = targetRow.locator('.drag-and-drop-cell');
 
+        await targetField.scrollIntoViewIfNeeded();
         await sourceField.dragTo(targetField);
       }
     }


### PR DESCRIPTION
closes #163

- this fix is difficult to verify because I
  believe the issue only occurs when there
  are enough apps in the list to push
  the target field out of view
- may have to revisit after more testing
