### PR TITLE
fix: address delete trigger js error

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -30,6 +30,7 @@
     "numerictextbox",
     "onspringend",
     "optionlabel",
+    "pageerror",
     "pwservice",
     "Regology",
     "signin",

--- a/fixtures/auth.fixtures.ts
+++ b/fixtures/auth.fixtures.ts
@@ -55,6 +55,19 @@ export async function createBaseAuthPage(
 
   page.on('response', errorResponseHandler);
 
+  page.on('pageerror', async error => {
+    const err = {
+      name: error.name,
+      message: error.message,
+      stack: error.stack,
+    };
+
+    await testInfo.attach(error.name, {
+      body: JSON.stringify(err, null, 2),
+      contentType: 'application/json',
+    });
+  });
+
   try {
     await use(page);
     await context.close();

--- a/tests/triggers/triggers.spec.ts
+++ b/tests/triggers/triggers.spec.ts
@@ -171,6 +171,8 @@ test.describe('Triggers', () => {
     });
 
     await test.step('Delete the trigger', async () => {
+      await appAdminPage.goto(app.id);
+      await appAdminPage.triggersTabButton.click();
       await appAdminPage.triggersTab.deleteTrigger(trigger.name);
     });
 


### PR DESCRIPTION
closes #169

- **chore: whitelist word**
- **feat: add pageerror handler and attach page errors to test results.**
- **fix: navigate back to trigger tab before deleting**
