### PR TITLE
fix: address disable dashboard flakiness

### DIFF
--- a/fixtures/container.fixtures.ts
+++ b/fixtures/container.fixtures.ts
@@ -33,7 +33,7 @@ async function createContainer(sysAdminPage: Page, containerName: string) {
   const id = editContainerPage.getIdFromUrl();
   const container = new Container({ id, name: containerName });
 
-  const cleanup = () => containersAdminPage.deleteContainers([containerName]);
+  const cleanup = async () => await containersAdminPage.deleteContainers([containerName]);
 
   return { container, cleanup };
 }

--- a/setups/auth.apiSetup.ts
+++ b/setups/auth.apiSetup.ts
@@ -10,6 +10,8 @@ const setup = setupBase.extend<ApiTestOptions>({
 });
 
 setup('Setup before API tests', async ({ page, useCachedApiSetup }) => {
+  setup.slow();
+
   const loginPage = new LoginPage(page);
   const dashboardPage = new DashboardPage(page);
   const sysAdminUser = UserFactory.createSysAdminUser();

--- a/tests/dashboard/dashboard.spec.ts
+++ b/tests/dashboard/dashboard.spec.ts
@@ -740,8 +740,6 @@ test.describe('dashboard', () => {
       ],
     });
 
-    dashboardsToDelete.push(dashboard.name);
-
     await test.step('Navigate to the Dashboards admin page', async () => {
       await dashboardsAdminPage.goto();
     });

--- a/tests/dashboard/dashboard.spec.ts
+++ b/tests/dashboard/dashboard.spec.ts
@@ -721,7 +721,7 @@ test.describe('dashboard', () => {
     });
   });
 
-  test('Disable a dashboard', async ({ report, container, dashboardsAdminPage }) => {
+  test('Disable a dashboard', async ({ report, container, dashboardsAdminPage, testUserPage }) => {
     test.info().annotations.push({
       type: AnnotationType.TestId,
       description: 'Test-330',
@@ -753,9 +753,13 @@ test.describe('dashboard', () => {
     });
 
     await test.step('Verify the dashboard is disabled', async () => {
-      await dashboardsAdminPage.sidebar.dashboardsTab.click();
+      const dashboardPage = new DashboardPage(testUserPage);
 
-      const containerLink = dashboardsAdminPage.sidebar.getContainerLink(container.name);
+      await dashboardPage.goto();
+      await dashboardPage.sidebar.dashboardsTab.click();
+      await dashboardPage.page.waitForURL(dashboardPage.path);
+
+      const containerLink = dashboardPage.sidebar.getContainerLink(container.name);
       await expect(containerLink).toBeHidden();
     });
   });


### PR DESCRIPTION
closes #216

- **fix: change cleanup method**
- **fix: try avoiding deleting dashboard in after each hook**
- **fix: mark api setup as slow**
- **fix: use test user for verify dashboard is disabled**
- **fix: [skip ci]**
