### PR TITLE
feat: add tests for dashboard objects

### DIFF
--- a/cleanup/global.cleanup.ts
+++ b/cleanup/global.cleanup.ts
@@ -65,7 +65,10 @@ teardown.describe('cleanup', () => {
     await new DashboardsAdminPage(sysAdminPage).deleteAllTestDashboards();
   });
 
-  teardown('cleanup:dashboardObjects delete all test dashboard objects created as part of tests', async ({ sysAdminPage }) => {
-    await new DashboardsAdminPage(sysAdminPage).deleteAllTestDashboardObjects();
-  });
+  teardown(
+    'cleanup:dashboardObjects delete all test dashboard objects created as part of tests',
+    async ({ sysAdminPage }) => {
+      await new DashboardsAdminPage(sysAdminPage).deleteAllTestDashboardObjects();
+    }
+  );
 });

--- a/cleanup/global.cleanup.ts
+++ b/cleanup/global.cleanup.ts
@@ -64,4 +64,8 @@ teardown.describe('cleanup', () => {
   teardown('cleanup:dashboards delete all test dashboards created as part of tests', async ({ sysAdminPage }) => {
     await new DashboardsAdminPage(sysAdminPage).deleteAllTestDashboards();
   });
+
+  teardown('cleanup:dashboardObjects delete all test dashboard objects created as part of tests', async ({ sysAdminPage }) => {
+    await new DashboardsAdminPage(sysAdminPage).deleteAllTestDashboardObjects();
+  });
 });

--- a/componentObjectModels/dialogs/addObjectDialog.ts
+++ b/componentObjectModels/dialogs/addObjectDialog.ts
@@ -1,0 +1,12 @@
+import { Page } from '@playwright/test';
+import { BaseCreateOrAddDialogWithContinueButton } from './baseCreateOrAddDialog';
+
+export class AddObjectDialog extends BaseCreateOrAddDialogWithContinueButton {
+  constructor(page: Page) {
+    super(page);
+  }
+
+  getObjectToCopy(itemName: string) {
+    return this.getItemToCopy(itemName);
+  }
+}

--- a/componentObjectModels/dialogs/deleteDashboardObjectDialog.ts
+++ b/componentObjectModels/dialogs/deleteDashboardObjectDialog.ts
@@ -1,0 +1,8 @@
+import { Page } from '@playwright/test';
+import { BaseDeleteDialog } from './baseDeleteDialog';
+
+export class DeleteDashboardObjectDialog extends BaseDeleteDialog {
+  constructor(page: Page) {
+    super(page);
+  }
+}

--- a/componentObjectModels/modals/addOrEditAppSearchObjectModal.ts
+++ b/componentObjectModels/modals/addOrEditAppSearchObjectModal.ts
@@ -1,54 +1,21 @@
-import { Locator, Page } from "../../fixtures";
-import { AppSearch } from "../../models/appSearch";
-import { DualPaneSelector } from "../controls/dualPaneSelector";
+import { Page } from '../../fixtures';
+import { AppSearch } from '../../models/appSearch';
+import { DualPaneSelector } from '../controls/dualPaneSelector';
+import { AddOrEditDashboardObjectItemModal } from './addOrEditDashboardObjectItemModal';
 
-export class AddOrEditAppSearchObjectModal {
-  private readonly modal: Locator;
-  private readonly generalTabButton: Locator;
-  private readonly nameInput: Locator;
+export class AddOrEditAppSearchObjectModal extends AddOrEditDashboardObjectItemModal {
   private readonly appsSelector: DualPaneSelector;
-  private readonly hideHeaderCheckbox: Locator;
-  private readonly hideContainerCheckbox: Locator;
-  private readonly securityTabButton: Locator;
-  private readonly viewSelector: Locator;
-  private readonly rolesSelector: DualPaneSelector;
-  private readonly saveButton: Locator;
 
   constructor(page: Page) {
-    this.modal = page.getByRole('dialog', { name: /Add.*Object/ });
-    this.generalTabButton = this.modal.getByRole('tab', { name: 'General' });
-    this.nameInput = this.modal.locator('.label:has-text("Name") + .data').getByRole('textbox');
-    this.appsSelector = new DualPaneSelector(this.modal.locator('.label:has-text("Apps") + .data .onx-selector'));
-    this.hideHeaderCheckbox = this.modal.getByRole('checkbox', { name: 'Hide object header' });
-    this.hideContainerCheckbox = this.modal.getByRole('checkbox', { name: 'Hide object container' });
-    this.securityTabButton = this.modal.getByRole('tab', { name: 'Security' });
-    this.viewSelector = this.modal.locator('.label:has-text("View") + .data').getByRole('listbox');
-    this.rolesSelector = new DualPaneSelector(this.modal.locator('.label:has-text("Roles") + .data .onx-selector'));
-    this.saveButton = this.modal.getByRole('button', { name: 'Save' });
-  }
+    super(page);
 
-  private async selectView(view: string) {
-    await this.viewSelector.click();
-    await this.viewSelector.page().getByRole('option', { name: view }).click();
+    this.appsSelector = new DualPaneSelector(this.modal.locator('.label:has-text("Apps") + .data .onx-selector'));
   }
 
   async fillOutForm(appSearch: AppSearch) {
-    await this.generalTabButton.click();
-    await this.nameInput.fill(appSearch.name);
+    await this.fillOutGeneralTab(appSearch);
     await this.appsSelector.selectOptions(appSearch.apps);
-    await this.hideHeaderCheckbox.setChecked(appSearch.hideHeader);
-    await this.hideContainerCheckbox.setChecked(appSearch.hideContainer);
 
-    await this.securityTabButton.click();
-    await this.selectView(appSearch.view);
-    
-    if (appSearch.view === 'Private by Role') {
-      await this.rolesSelector.selectOptions(appSearch.roles);
-    }
-  }
-
-  async save() {
-    await this.saveButton.click();
-    await this.modal.waitFor({ state: 'hidden' });
+    await this.fillOutSecurityTab(appSearch);
   }
 }

--- a/componentObjectModels/modals/addOrEditAppSearchObjectModal.ts
+++ b/componentObjectModels/modals/addOrEditAppSearchObjectModal.ts
@@ -1,0 +1,54 @@
+import { Locator, Page } from "../../fixtures";
+import { AppSearch } from "../../models/appSearch";
+import { DualPaneSelector } from "../controls/dualPaneSelector";
+
+export class AddOrEditAppSearchObjectModal {
+  private readonly modal: Locator;
+  private readonly generalTabButton: Locator;
+  private readonly nameInput: Locator;
+  private readonly appsSelector: DualPaneSelector;
+  private readonly hideHeaderCheckbox: Locator;
+  private readonly hideContainerCheckbox: Locator;
+  private readonly securityTabButton: Locator;
+  private readonly viewSelector: Locator;
+  private readonly rolesSelector: DualPaneSelector;
+  private readonly saveButton: Locator;
+
+  constructor(page: Page) {
+    this.modal = page.getByRole('dialog', { name: /Add.*Object/ });
+    this.generalTabButton = this.modal.getByRole('tab', { name: 'General' });
+    this.nameInput = this.modal.locator('.label:has-text("Name") + .data').getByRole('textbox');
+    this.appsSelector = new DualPaneSelector(this.modal.locator('.label:has-text("Apps") + .data .onx-selector'));
+    this.hideHeaderCheckbox = this.modal.getByRole('checkbox', { name: 'Hide object header' });
+    this.hideContainerCheckbox = this.modal.getByRole('checkbox', { name: 'Hide object container' });
+    this.securityTabButton = this.modal.getByRole('tab', { name: 'Security' });
+    this.viewSelector = this.modal.locator('.label:has-text("View") + .data').getByRole('listbox');
+    this.rolesSelector = new DualPaneSelector(this.modal.locator('.label:has-text("Roles") + .data .onx-selector'));
+    this.saveButton = this.modal.getByRole('button', { name: 'Save' });
+  }
+
+  private async selectView(view: string) {
+    await this.viewSelector.click();
+    await this.viewSelector.page().getByRole('option', { name: view }).click();
+  }
+
+  async fillOutForm(appSearch: AppSearch) {
+    await this.generalTabButton.click();
+    await this.nameInput.fill(appSearch.name);
+    await this.appsSelector.selectOptions(appSearch.apps);
+    await this.hideHeaderCheckbox.setChecked(appSearch.hideHeader);
+    await this.hideContainerCheckbox.setChecked(appSearch.hideContainer);
+
+    await this.securityTabButton.click();
+    await this.selectView(appSearch.view);
+    
+    if (appSearch.view === 'Private by Role') {
+      await this.rolesSelector.selectOptions(appSearch.roles);
+    }
+  }
+
+  async save() {
+    await this.saveButton.click();
+    await this.modal.waitFor({ state: 'hidden' });
+  }
+}

--- a/componentObjectModels/modals/addOrEditCreateContentLinksObjectModal.ts
+++ b/componentObjectModels/modals/addOrEditCreateContentLinksObjectModal.ts
@@ -1,0 +1,78 @@
+import { Locator, Page } from '../../fixtures';
+import { CreateContentLinks } from '../../models/createContentLinks';
+import { DualPaneSelector } from '../controls/dualPaneSelector';
+
+export class AddOrEditCreateContentLinksObjectModal {
+  private readonly modal: Locator;
+  private readonly generalTabButton: Locator;
+  private readonly nameInput: Locator;
+  private readonly addLinkButton: Locator;
+  private readonly linksGridBody: Locator;
+  private readonly hideHeaderCheckbox: Locator;
+  private readonly hideContainerCheckbox: Locator;
+  private readonly securityTabButton: Locator;
+  private readonly viewSelector: Locator;
+  private readonly rolesSelector: DualPaneSelector;
+  private readonly saveButton: Locator;
+
+  constructor(page: Page) {
+    this.modal = page.getByRole('dialog', { name: /Add.*Object/ });
+    this.generalTabButton = this.modal.getByRole('tab', { name: 'General' });
+    this.nameInput = this.modal.locator('.label:has-text("Name") + .data').getByRole('textbox');
+    this.addLinkButton = this.modal.getByRole('button', { name: 'Add a Link' });
+    this.linksGridBody = this.modal.locator('.label:has-text("Links") + .data').locator('.k-grid-content');
+    this.hideHeaderCheckbox = this.modal.getByRole('checkbox', { name: 'Hide object header' });
+    this.hideContainerCheckbox = this.modal.getByRole('checkbox', { name: 'Hide object container' });
+    this.securityTabButton = this.modal.getByRole('tab', { name: 'Security' });
+    this.viewSelector = this.modal.locator('.label:has-text("View") + .data').getByRole('listbox');
+    this.rolesSelector = new DualPaneSelector(this.modal.locator('.label:has-text("Roles") + .data .onx-selector'));
+    this.saveButton = this.modal.getByRole('button', { name: 'Save' });
+  }
+
+  private async selectView(view: string) {
+    await this.viewSelector.click();
+    await this.viewSelector.page().getByRole('option', { name: view }).click();
+  }
+
+  private async addLinks(createContentLinks: CreateContentLinks) {
+    for (const link of createContentLinks.links) {
+      await this.addLinkButton.click();
+      const lastRow = this.linksGridBody.locator('tr').last();
+      const appSelector = lastRow.locator('td').nth(1).getByRole('listbox');
+      const sourceSelector = lastRow.locator('td').nth(2).getByRole('listbox');
+      const linkTextInput = lastRow.locator('td').nth(4).getByRole('textbox');
+
+      await appSelector.click();
+      await appSelector.page().getByRole('option', { name: link.app }).click();
+
+      if (link.imageSource.src === 'Library') {
+        throw new Error('Not implemented');
+      }
+
+      await sourceSelector.click();
+      await sourceSelector.page().getByRole('option', { name: link.imageSource.src }).click();
+
+      await linkTextInput.fill(link.linkText);
+    }
+  }
+
+  async fillOutForm(createContentLinks: CreateContentLinks) {
+    await this.generalTabButton.click();
+    await this.nameInput.fill(createContentLinks.name);
+    await this.addLinks(createContentLinks);
+    await this.hideHeaderCheckbox.setChecked(createContentLinks.hideHeader);
+    await this.hideContainerCheckbox.setChecked(createContentLinks.hideContainer);
+
+    await this.securityTabButton.click();
+    await this.selectView(createContentLinks.view);
+
+    if (createContentLinks.view === 'Private by Role') {
+      await this.rolesSelector.selectOptions(createContentLinks.roles);
+    }
+  }
+
+  async save() {
+    await this.saveButton.click();
+    await this.modal.waitFor({ state: 'hidden' });
+  }
+}

--- a/componentObjectModels/modals/addOrEditCreateContentLinksObjectModal.ts
+++ b/componentObjectModels/modals/addOrEditCreateContentLinksObjectModal.ts
@@ -13,6 +13,18 @@ export class AddOrEditCreateContentLinksObjectModal extends AddOrEditDashboardOb
     this.linksGridBody = this.modal.locator('.label:has-text("Links") + .data').locator('.k-grid-content');
   }
 
+  private async clearLinkGrid() {
+    const rows = this.linksGridBody.locator('tr');
+    const count = await rows.count();
+
+    for (let i = 0; i < count; i++) {
+      const row = rows.nth(0);
+      await row.hover();
+      await row.getByTitle('Delete').click();
+      await row.waitFor({ state: 'hidden' });
+    }
+  }
+
   private async addLinks(createContentLinks: CreateContentLinks) {
     for (const link of createContentLinks.links) {
       await this.addLinkButton.click();
@@ -37,6 +49,7 @@ export class AddOrEditCreateContentLinksObjectModal extends AddOrEditDashboardOb
 
   async fillOutForm(createContentLinks: CreateContentLinks) {
     await this.fillOutGeneralTab(createContentLinks);
+    await this.clearLinkGrid();
     await this.addLinks(createContentLinks);
 
     await this.fillOutSecurityTab(createContentLinks);

--- a/componentObjectModels/modals/addOrEditCreateContentLinksObjectModal.ts
+++ b/componentObjectModels/modals/addOrEditCreateContentLinksObjectModal.ts
@@ -1,37 +1,16 @@
 import { Locator, Page } from '../../fixtures';
 import { CreateContentLinks } from '../../models/createContentLinks';
-import { DualPaneSelector } from '../controls/dualPaneSelector';
+import { AddOrEditDashboardObjectItemModal } from './addOrEditDashboardObjectItemModal';
 
-export class AddOrEditCreateContentLinksObjectModal {
-  private readonly modal: Locator;
-  private readonly generalTabButton: Locator;
-  private readonly nameInput: Locator;
+export class AddOrEditCreateContentLinksObjectModal extends AddOrEditDashboardObjectItemModal {
   private readonly addLinkButton: Locator;
   private readonly linksGridBody: Locator;
-  private readonly hideHeaderCheckbox: Locator;
-  private readonly hideContainerCheckbox: Locator;
-  private readonly securityTabButton: Locator;
-  private readonly viewSelector: Locator;
-  private readonly rolesSelector: DualPaneSelector;
-  private readonly saveButton: Locator;
 
   constructor(page: Page) {
-    this.modal = page.getByRole('dialog', { name: /Add.*Object/ });
-    this.generalTabButton = this.modal.getByRole('tab', { name: 'General' });
-    this.nameInput = this.modal.locator('.label:has-text("Name") + .data').getByRole('textbox');
+    super(page);
+
     this.addLinkButton = this.modal.getByRole('button', { name: 'Add a Link' });
     this.linksGridBody = this.modal.locator('.label:has-text("Links") + .data').locator('.k-grid-content');
-    this.hideHeaderCheckbox = this.modal.getByRole('checkbox', { name: 'Hide object header' });
-    this.hideContainerCheckbox = this.modal.getByRole('checkbox', { name: 'Hide object container' });
-    this.securityTabButton = this.modal.getByRole('tab', { name: 'Security' });
-    this.viewSelector = this.modal.locator('.label:has-text("View") + .data').getByRole('listbox');
-    this.rolesSelector = new DualPaneSelector(this.modal.locator('.label:has-text("Roles") + .data .onx-selector'));
-    this.saveButton = this.modal.getByRole('button', { name: 'Save' });
-  }
-
-  private async selectView(view: string) {
-    await this.viewSelector.click();
-    await this.viewSelector.page().getByRole('option', { name: view }).click();
   }
 
   private async addLinks(createContentLinks: CreateContentLinks) {
@@ -57,22 +36,9 @@ export class AddOrEditCreateContentLinksObjectModal {
   }
 
   async fillOutForm(createContentLinks: CreateContentLinks) {
-    await this.generalTabButton.click();
-    await this.nameInput.fill(createContentLinks.name);
+    await this.fillOutGeneralTab(createContentLinks);
     await this.addLinks(createContentLinks);
-    await this.hideHeaderCheckbox.setChecked(createContentLinks.hideHeader);
-    await this.hideContainerCheckbox.setChecked(createContentLinks.hideContainer);
 
-    await this.securityTabButton.click();
-    await this.selectView(createContentLinks.view);
-
-    if (createContentLinks.view === 'Private by Role') {
-      await this.rolesSelector.selectOptions(createContentLinks.roles);
-    }
-  }
-
-  async save() {
-    await this.saveButton.click();
-    await this.modal.waitFor({ state: 'hidden' });
+    await this.fillOutSecurityTab(createContentLinks);
   }
 }

--- a/componentObjectModels/modals/addOrEditDashboardObjectItemModal.ts
+++ b/componentObjectModels/modals/addOrEditDashboardObjectItemModal.ts
@@ -1,0 +1,55 @@
+import { Locator, Page } from "@playwright/test";
+import { DualPaneSelector } from "../controls/dualPaneSelector";
+import { DashboardObjectItem } from "../../models/dashboardObjectItem";
+
+export abstract class AddOrEditDashboardObjectItemModal {
+  private readonly viewSelector: Locator;
+  private readonly saveButton: Locator;
+  protected readonly modal: Locator;
+  protected readonly generalTabButton: Locator;
+  protected readonly nameInput: Locator;
+  protected readonly hideHeaderCheckbox: Locator;
+  protected readonly hideContainerCheckbox: Locator;
+  protected readonly securityTabButton: Locator;
+  protected readonly rolesSelector: DualPaneSelector;
+
+  constructor(page: Page) {
+    this.modal = page.getByRole('dialog', { name: /Add.*Object/ });
+    this.generalTabButton = this.modal.getByRole('tab', { name: 'General' });
+    this.nameInput = this.modal.locator('.label:has-text("Name") + .data').getByRole('textbox');
+    this.hideHeaderCheckbox = this.modal.getByRole('checkbox', { name: 'Hide object header' });
+    this.hideContainerCheckbox = this.modal.getByRole('checkbox', { name: 'Hide object container' });
+    this.securityTabButton = this.modal.getByRole('tab', { name: 'Security' });
+    this.viewSelector = this.modal.locator('.label:has-text("View") + .data').getByRole('listbox');
+    this.rolesSelector = new DualPaneSelector(this.modal.locator('.label:has-text("Roles") + .data .onx-selector'));
+    this.saveButton = this.modal.getByRole('button', { name: 'Save' });
+  }
+
+  private async selectView(view: string) {
+    await this.viewSelector.click();
+    await this.viewSelector.page().getByRole('option', { name: view }).click();
+  }
+
+  protected async fillOutGeneralTab(dashboardObjectItem: DashboardObjectItem) {
+    await this.generalTabButton.click();
+    await this.nameInput.fill(dashboardObjectItem.name);
+    await this.hideHeaderCheckbox.setChecked(dashboardObjectItem.hideHeader);
+    await this.hideContainerCheckbox.setChecked(dashboardObjectItem.hideContainer);
+  }
+
+  protected async fillOutSecurityTab(dashboardObjectItem: DashboardObjectItem) {
+    await this.securityTabButton.click();
+    await this.selectView(dashboardObjectItem.view);
+
+    if (dashboardObjectItem.view === 'Private by Role') {
+      await this.rolesSelector.selectOptions(dashboardObjectItem.roles);
+    }
+  }
+
+  abstract fillOutForm(dashboardObjectItem: DashboardObjectItem): Promise<void>;
+
+  async save() {
+    await this.saveButton.click();
+    await this.modal.waitFor({ state: 'hidden' });
+  }
+}

--- a/componentObjectModels/modals/addOrEditDashboardObjectItemModal.ts
+++ b/componentObjectModels/modals/addOrEditDashboardObjectItemModal.ts
@@ -1,6 +1,6 @@
-import { Locator, Page } from "@playwright/test";
-import { DualPaneSelector } from "../controls/dualPaneSelector";
-import { DashboardObjectItem } from "../../models/dashboardObjectItem";
+import { Locator, Page } from '@playwright/test';
+import { DualPaneSelector } from '../controls/dualPaneSelector';
+import { DashboardObjectItem } from '../../models/dashboardObjectItem';
 
 export abstract class AddOrEditDashboardObjectItemModal {
   private readonly viewSelector: Locator;

--- a/componentObjectModels/modals/addOrEditDashboardObjectItemModal.ts
+++ b/componentObjectModels/modals/addOrEditDashboardObjectItemModal.ts
@@ -14,7 +14,7 @@ export abstract class AddOrEditDashboardObjectItemModal {
   protected readonly rolesSelector: DualPaneSelector;
 
   constructor(page: Page) {
-    this.modal = page.getByRole('dialog', { name: /Add.*Object/ });
+    this.modal = page.getByRole('dialog', { name: /Object/ });
     this.generalTabButton = this.modal.getByRole('tab', { name: 'General' });
     this.nameInput = this.modal.locator('.label:has-text("Name") + .data').getByRole('textbox');
     this.hideHeaderCheckbox = this.modal.getByRole('checkbox', { name: 'Hide object header' });

--- a/componentObjectModels/modals/addOrEditFormattedTextBlockObjectModal.ts
+++ b/componentObjectModels/modals/addOrEditFormattedTextBlockObjectModal.ts
@@ -1,51 +1,21 @@
 import { Locator, Page } from "@playwright/test";
-import { DualPaneSelector } from "../controls/dualPaneSelector";
 import { DashboardFormattedTextBlock } from "../../models/dashboardFormattedTextBlock";
+import { AddOrEditDashboardObjectItemModal } from "./addOrEditDashboardObjectItemModal";
 
-export class AddOrEditFormattedTextBlockObjectModal {
-  private readonly modal: Locator;
-  private readonly generalTabButton: Locator;
-  private readonly nameInput: Locator;
-  private readonly hideHeaderCheckbox: Locator;
-  private readonly hideContainerCheckbox: Locator;
-  private readonly securityTabButton: Locator;
-  private readonly viewSelector: Locator;
-  private readonly rolesSelector: DualPaneSelector;
-  private readonly saveButton: Locator;
-  
+export class AddOrEditFormattedTextBlockObjectModal extends AddOrEditDashboardObjectItemModal {
+  private readonly formattedTextEditor: Locator;
+
   constructor(page: Page) {
-    this.modal = page.getByRole("dialog", { name: /Add.*Object/ });
-    this.generalTabButton = this.modal.getByRole("tab", { name: "General" });
-    this.nameInput = this.modal.locator('.label:has-text("Name") + .data').getByRole("textbox");
-    this.hideHeaderCheckbox = this.modal.getByRole("checkbox", { name: "Hide object header" });
-    this.hideContainerCheckbox = this.modal.getByRole("checkbox", { name: "Hide object container" });
-    this.securityTabButton = this.modal.getByRole("tab", { name: "Security" });
-    this.viewSelector = this.modal.locator('.label:has-text("View") + .data').getByRole("listbox");
-    this.rolesSelector = new DualPaneSelector(this.modal.locator('.label:has-text("Roles") + .data .onx-selector'));
-    this.saveButton = this.modal.getByRole("button", { name: "Save" });
-  }
-
-  private async selectView(view: string) {
-    await this.viewSelector.click();
-    await this.viewSelector.page().getByRole("option", { name: view }).click();
+    super(page);
+    
+    this.formattedTextEditor = this.modal.locator('.content-area.mce-content-body');
   }
 
   async fillOutForm(formattedTextBlock: DashboardFormattedTextBlock) {
-    await this.generalTabButton.click();
-    await this.nameInput.fill(formattedTextBlock.name);
-    await this.hideHeaderCheckbox.setChecked(formattedTextBlock.hideHeader);
-    await this.hideContainerCheckbox.setChecked(formattedTextBlock.hideContainer);
-    await this.securityTabButton.click();
-    await this.selectView(formattedTextBlock.view);
+    await this.fillOutGeneralTab(formattedTextBlock);
+    await this.formattedTextEditor.fill(formattedTextBlock.formattedText);
 
-    if (formattedTextBlock.view === 'Private by Role') {
-      await this.rolesSelector.selectOptions(formattedTextBlock.roles);
-    }
-  }
-
-  async save() {
-    await this.saveButton.click();
-    await this.modal.waitFor({ state: "hidden" });
+    await this.fillOutSecurityTab(formattedTextBlock);
   }
 }
 

--- a/componentObjectModels/modals/addOrEditFormattedTextBlockObjectModal.ts
+++ b/componentObjectModels/modals/addOrEditFormattedTextBlockObjectModal.ts
@@ -1,13 +1,13 @@
-import { Locator, Page } from "@playwright/test";
-import { DashboardFormattedTextBlock } from "../../models/dashboardFormattedTextBlock";
-import { AddOrEditDashboardObjectItemModal } from "./addOrEditDashboardObjectItemModal";
+import { Locator, Page } from '@playwright/test';
+import { DashboardFormattedTextBlock } from '../../models/dashboardFormattedTextBlock';
+import { AddOrEditDashboardObjectItemModal } from './addOrEditDashboardObjectItemModal';
 
 export class AddOrEditFormattedTextBlockObjectModal extends AddOrEditDashboardObjectItemModal {
   private readonly formattedTextEditor: Locator;
 
   constructor(page: Page) {
     super(page);
-    
+
     this.formattedTextEditor = this.modal.locator('.content-area.mce-content-body');
   }
 
@@ -18,5 +18,3 @@ export class AddOrEditFormattedTextBlockObjectModal extends AddOrEditDashboardOb
     await this.fillOutSecurityTab(formattedTextBlock);
   }
 }
-
-

--- a/componentObjectModels/modals/addOrEditFormattedTextBlockObjectModal.ts
+++ b/componentObjectModels/modals/addOrEditFormattedTextBlockObjectModal.ts
@@ -1,4 +1,6 @@
 import { Locator, Page } from "@playwright/test";
+import { DualPaneSelector } from "../controls/dualPaneSelector";
+import { DashboardFormattedTextBlock } from "../../models/dashboardFormattedTextBlock";
 
 export class AddOrEditFormattedTextBlockObjectModal {
   private readonly modal: Locator;
@@ -13,6 +15,37 @@ export class AddOrEditFormattedTextBlockObjectModal {
   
   constructor(page: Page) {
     this.modal = page.getByRole("dialog", { name: /Add.*Object/ });
+    this.generalTabButton = this.modal.getByRole("tab", { name: "General" });
+    this.nameInput = this.modal.locator('.label:has-text("Name") + .data').getByRole("textbox");
+    this.hideHeaderCheckbox = this.modal.getByRole("checkbox", { name: "Hide object header" });
+    this.hideContainerCheckbox = this.modal.getByRole("checkbox", { name: "Hide object container" });
+    this.securityTabButton = this.modal.getByRole("tab", { name: "Security" });
+    this.viewSelector = this.modal.locator('.label:has-text("View") + .data').getByRole("listbox");
+    this.rolesSelector = new DualPaneSelector(this.modal.locator('.label:has-text("Roles") + .data .onx-selector'));
+    this.saveButton = this.modal.getByRole("button", { name: "Save" });
+  }
+
+  private async selectView(view: string) {
+    await this.viewSelector.click();
+    await this.viewSelector.page().getByRole("option", { name: view }).click();
+  }
+
+  async fillOutForm(formattedTextBlock: DashboardFormattedTextBlock) {
+    await this.generalTabButton.click();
+    await this.nameInput.fill(formattedTextBlock.name);
+    await this.hideHeaderCheckbox.setChecked(formattedTextBlock.hideHeader);
+    await this.hideContainerCheckbox.setChecked(formattedTextBlock.hideContainer);
+    await this.securityTabButton.click();
+    await this.selectView(formattedTextBlock.view);
+
+    if (formattedTextBlock.view === 'Private by Role') {
+      await this.rolesSelector.selectOptions(formattedTextBlock.roles);
+    }
+  }
+
+  async save() {
+    await this.saveButton.click();
+    await this.modal.waitFor({ state: "hidden" });
   }
 }
 

--- a/componentObjectModels/modals/addOrEditFormattedTextBlockObjectModal.ts
+++ b/componentObjectModels/modals/addOrEditFormattedTextBlockObjectModal.ts
@@ -1,0 +1,19 @@
+import { Locator, Page } from "@playwright/test";
+
+export class AddOrEditFormattedTextBlockObjectModal {
+  private readonly modal: Locator;
+  private readonly generalTabButton: Locator;
+  private readonly nameInput: Locator;
+  private readonly hideHeaderCheckbox: Locator;
+  private readonly hideContainerCheckbox: Locator;
+  private readonly securityTabButton: Locator;
+  private readonly viewSelector: Locator;
+  private readonly rolesSelector: DualPaneSelector;
+  private readonly saveButton: Locator;
+  
+  constructor(page: Page) {
+    this.modal = page.getByRole("dialog", { name: /Add.*Object/ });
+  }
+}
+
+

--- a/componentObjectModels/modals/addOrEditWebPageObjectModal.ts
+++ b/componentObjectModels/modals/addOrEditWebPageObjectModal.ts
@@ -1,54 +1,23 @@
 import { Locator, Page } from "@playwright/test";
-import { DualPaneSelector } from "../controls/dualPaneSelector";
 import { WebPage } from "../../models/webPage";
+import { AddOrEditDashboardObjectItemModal } from "./addOrEditDashboardObjectItemModal";
 
-export class AddOrEditWebPageObjectModal {
-  private readonly modal: Locator;
-  private readonly generalTabButton: Locator;
-  private readonly nameInput: Locator;
+export class AddOrEditWebPageObjectModal extends AddOrEditDashboardObjectItemModal {
   private readonly urlInput: Locator;
-  private readonly hideHeaderCheckbox: Locator;
-  private readonly hideContainerCheckbox: Locator;
-  private readonly securityTabButton: Locator;
-  private readonly viewSelector: Locator;
-  private readonly rolesSelector: DualPaneSelector;
-  private readonly saveButton: Locator;
+  private readonly forceRefreshCheckbox: Locator;
 
   constructor(page: Page) {
-    this.modal = page.getByRole('dialog', { name: /Add.*Object/ });
-    this.generalTabButton = this.modal.getByRole('tab', { name: 'General' });
-    this.nameInput = this.modal.locator('.label:has-text("Name") + .data').getByRole('textbox');
-    this.urlInput = this.modal.locator('.label:has-text("URL") + .data').getByRole('textbox');
-    this.hideHeaderCheckbox = this.modal.getByRole('checkbox', { name: 'Hide object header' });
-    this.hideContainerCheckbox = this.modal.getByRole('checkbox', { name: 'Hide object container' });
-    this.securityTabButton = this.modal.getByRole('tab', { name: 'Security' });
-    this.viewSelector = this.modal.locator('.label:has-text("View") + .data').getByRole('listbox');
-    this.rolesSelector = new DualPaneSelector(this.modal.locator('.label:has-text("Roles") + .data .onx-selector'));
-    this.saveButton = this.modal.getByRole('button', { name: 'Save' });
-  }
+    super(page);
 
-  private async selectView(view: string) {
-    await this.viewSelector.click();
-    await this.viewSelector.page().getByRole('option', { name: view }).click();
+    this.urlInput = this.modal.locator('.label:has-text("URL") + .data').getByRole('textbox');
+    this.forceRefreshCheckbox = this.modal.getByRole('checkbox', { name: 'Automatically refresh the content of the web page every 60 seconds' });
   }
 
   async fillOutForm(webPage: WebPage) {
-    await this.generalTabButton.click();
-    await this.nameInput.fill(webPage.name);
+    await this.fillOutGeneralTab(webPage);
     await this.urlInput.fill(webPage.url);
-    await this.hideHeaderCheckbox.setChecked(webPage.hideHeader);
-    await this.hideContainerCheckbox.setChecked(webPage.hideContainer);
+    await this.forceRefreshCheckbox.setChecked(webPage.forceRefresh);
 
-    await this.securityTabButton.click();
-    await this.selectView(webPage.view);
-
-    if (webPage.view === 'Private by Role') {
-      await this.rolesSelector.selectOptions(webPage.roles);
-    }
-  }
-
-  async save() {
-    await this.saveButton.click();
-    await this.modal.waitFor({ state: 'hidden' });
+    await this.fillOutSecurityTab(webPage);
   }
 }

--- a/componentObjectModels/modals/addOrEditWebPageObjectModal.ts
+++ b/componentObjectModels/modals/addOrEditWebPageObjectModal.ts
@@ -1,0 +1,54 @@
+import { Locator, Page } from "@playwright/test";
+import { DualPaneSelector } from "../controls/dualPaneSelector";
+import { WebPage } from "../../models/webPage";
+
+export class AddOrEditWebPageObjectModal {
+  private readonly modal: Locator;
+  private readonly generalTabButton: Locator;
+  private readonly nameInput: Locator;
+  private readonly urlInput: Locator;
+  private readonly hideHeaderCheckbox: Locator;
+  private readonly hideContainerCheckbox: Locator;
+  private readonly securityTabButton: Locator;
+  private readonly viewSelector: Locator;
+  private readonly rolesSelector: DualPaneSelector;
+  private readonly saveButton: Locator;
+
+  constructor(page: Page) {
+    this.modal = page.getByRole('dialog', { name: /Add.*Object/ });
+    this.generalTabButton = this.modal.getByRole('tab', { name: 'General' });
+    this.nameInput = this.modal.locator('.label:has-text("Name") + .data').getByRole('textbox');
+    this.urlInput = this.modal.locator('.label:has-text("URL") + .data').getByRole('textbox');
+    this.hideHeaderCheckbox = this.modal.getByRole('checkbox', { name: 'Hide object header' });
+    this.hideContainerCheckbox = this.modal.getByRole('checkbox', { name: 'Hide object container' });
+    this.securityTabButton = this.modal.getByRole('tab', { name: 'Security' });
+    this.viewSelector = this.modal.locator('.label:has-text("View") + .data').getByRole('listbox');
+    this.rolesSelector = new DualPaneSelector(this.modal.locator('.label:has-text("Roles") + .data .onx-selector'));
+    this.saveButton = this.modal.getByRole('button', { name: 'Save' });
+  }
+
+  private async selectView(view: string) {
+    await this.viewSelector.click();
+    await this.viewSelector.page().getByRole('option', { name: view }).click();
+  }
+
+  async fillOutForm(webPage: WebPage) {
+    await this.generalTabButton.click();
+    await this.nameInput.fill(webPage.name);
+    await this.urlInput.fill(webPage.url);
+    await this.hideHeaderCheckbox.setChecked(webPage.hideHeader);
+    await this.hideContainerCheckbox.setChecked(webPage.hideContainer);
+
+    await this.securityTabButton.click();
+    await this.selectView(webPage.view);
+
+    if (webPage.view === 'Private by Role') {
+      await this.rolesSelector.selectOptions(webPage.roles);
+    }
+  }
+
+  async save() {
+    await this.saveButton.click();
+    await this.modal.waitFor({ state: 'hidden' });
+  }
+}

--- a/componentObjectModels/modals/addOrEditWebPageObjectModal.ts
+++ b/componentObjectModels/modals/addOrEditWebPageObjectModal.ts
@@ -1,6 +1,6 @@
-import { Locator, Page } from "@playwright/test";
-import { WebPage } from "../../models/webPage";
-import { AddOrEditDashboardObjectItemModal } from "./addOrEditDashboardObjectItemModal";
+import { Locator, Page } from '@playwright/test';
+import { WebPage } from '../../models/webPage';
+import { AddOrEditDashboardObjectItemModal } from './addOrEditDashboardObjectItemModal';
 
 export class AddOrEditWebPageObjectModal extends AddOrEditDashboardObjectItemModal {
   private readonly urlInput: Locator;
@@ -10,7 +10,9 @@ export class AddOrEditWebPageObjectModal extends AddOrEditDashboardObjectItemMod
     super(page);
 
     this.urlInput = this.modal.locator('.label:has-text("URL") + .data').getByRole('textbox');
-    this.forceRefreshCheckbox = this.modal.getByRole('checkbox', { name: 'Automatically refresh the content of the web page every 60 seconds' });
+    this.forceRefreshCheckbox = this.modal.getByRole('checkbox', {
+      name: 'Automatically refresh the content of the web page every 60 seconds',
+    });
   }
 
   async fillOutForm(webPage: WebPage) {

--- a/componentObjectModels/modals/dashboardDesignerModal.ts
+++ b/componentObjectModels/modals/dashboardDesignerModal.ts
@@ -235,7 +235,7 @@ export class DashboardDesignerModal {
     await this.resourcesSection.scrollAllObjectsIntoView();
 
     const item = await this.resourcesSection.getItemFromTabByName(TEST_DASHBOARD_OBJECT_NAME);
-    const object = item.last()
+    const object = item.last();
 
     let isVisible = await object.isVisible();
 
@@ -251,7 +251,7 @@ export class DashboardDesignerModal {
       await deleteResponse;
       await this.deleteDashboardObjectDialog.dialog.waitFor({ state: 'hidden' });
       await getMoreObjectsResponse;
-      
+
       isVisible = await object.isVisible();
     }
   }

--- a/componentObjectModels/modals/dashboardDesignerModal.ts
+++ b/componentObjectModels/modals/dashboardDesignerModal.ts
@@ -6,6 +6,9 @@ import { DashboardResourcesSection } from '../sections/dashboardResourcesSection
 import { DashboardPermissionsModal } from './dashboardPermissionsModal';
 import { DashboardPropertiesModal } from './dashboardPropertiesModal';
 import { ScheduleDashboardExportModal } from './scheduleDashboardExportModal';
+import { AppSearch } from '../../models/appSearch';
+import { AddObjectDialog } from '../dialogs/addObjectDialog';
+import { AddOrEditAppSearchObjectModal } from './addOrEditAppSearchObjectModal';
 
 export class DashboardDesignerModal {
   private readonly page: Page;
@@ -22,6 +25,8 @@ export class DashboardDesignerModal {
   private readonly schedulingModal: ScheduleDashboardExportModal;
   private readonly resourcesSection: DashboardResourcesSection;
   private readonly canvasSection: DashboardCanvasSection;
+  private readonly addObjectDialog: AddObjectDialog;
+  private readonly appSearchObjectModal: AddOrEditAppSearchObjectModal;
   readonly title: Locator;
 
   constructor(page: Page) {
@@ -40,6 +45,8 @@ export class DashboardDesignerModal {
     this.schedulingModal = new ScheduleDashboardExportModal(this.page);
     this.resourcesSection = new DashboardResourcesSection(this.designer);
     this.canvasSection = new DashboardCanvasSection(this.designer);
+    this.addObjectDialog = new AddObjectDialog(this.page);
+    this.appSearchObjectModal = new AddOrEditAppSearchObjectModal(this.page);
   }
 
   async waitFor(options?: WaitForOptions) {
@@ -144,5 +151,14 @@ export class DashboardDesignerModal {
     }
 
     return parseInt(id);
+  }
+
+  async addAppSearchObject(appSearchObject: AppSearch) {
+    await this.resourcesSection.selectObjectsTab();
+    await this.resourcesSection.clickAddObjectButton('App Search');
+    await this.addObjectDialog.continueButton.waitFor();
+    await this.addObjectDialog.continueButton.click();
+    await this.appSearchObjectModal.fillOutForm(appSearchObject);
+    await this.appSearchObjectModal.save();
   }
 }

--- a/componentObjectModels/modals/dashboardDesignerModal.ts
+++ b/componentObjectModels/modals/dashboardDesignerModal.ts
@@ -12,6 +12,7 @@ import { AddOrEditAppSearchObjectModal } from './addOrEditAppSearchObjectModal';
 import { CreateContentLinks } from '../../models/createContentLinks';
 import { AddOrEditCreateContentLinksObjectModal } from './addOrEditCreateContentLinksObjectModal';
 import { DashboardFormattedTextBlock } from '../../models/dashboardFormattedTextBlock';
+import { AddOrEditFormattedTextBlockObjectModal } from './addOrEditFormattedTextBlockObjectModal';
 
 export class DashboardDesignerModal {
   private readonly page: Page;
@@ -31,6 +32,7 @@ export class DashboardDesignerModal {
   private readonly addObjectDialog: AddObjectDialog;
   private readonly appSearchObjectModal: AddOrEditAppSearchObjectModal;
   private readonly createContentLinksObjectModal: AddOrEditCreateContentLinksObjectModal;
+  private readonly formattedTextBlockObjectModal: AddOrEditFormattedTextBlockObjectModal;
   readonly title: Locator;
 
   constructor(page: Page) {
@@ -183,6 +185,8 @@ export class DashboardDesignerModal {
     await this.resourcesSection.clickAddObjectButton('Formatted Text Block');
     await this.addObjectDialog.continueButton.waitFor();
     await this.addObjectDialog.continueButton.click();
+    await this.formattedTextBlockObjectModal.fillOutForm(formattedTextBlock);
+    await this.formattedTextBlockObjectModal.save();
 
   }
 }

--- a/componentObjectModels/modals/dashboardDesignerModal.ts
+++ b/componentObjectModels/modals/dashboardDesignerModal.ts
@@ -1,21 +1,22 @@
 import { FrameLocator, Locator, Page } from '@playwright/test';
-import { Dashboard, DashboardItemObject, DashboardItemWithLocation, DashboardSchedule } from '../../models/dashboard';
+import { AppSearch } from '../../models/appSearch';
+import { CreateContentLinks } from '../../models/createContentLinks';
+import { Dashboard, DashboardItemWithLocation, DashboardSchedule } from '../../models/dashboard';
+import { DashboardFormattedTextBlock } from '../../models/dashboardFormattedTextBlock';
+import { DashboardObjectItem } from '../../models/dashboardObjectItem';
+import { WebPage } from '../../models/webPage';
 import { WaitForOptions } from '../../utils';
+import { AddObjectDialog } from '../dialogs/addObjectDialog';
+import { DeleteDashboardObjectDialog } from '../dialogs/deleteDashboardObjectDialog';
 import { DashboardCanvasSection } from '../sections/dashboardCanvasSection';
 import { DashboardResourcesSection } from '../sections/dashboardResourcesSection';
+import { AddOrEditAppSearchObjectModal } from './addOrEditAppSearchObjectModal';
+import { AddOrEditCreateContentLinksObjectModal } from './addOrEditCreateContentLinksObjectModal';
+import { AddOrEditFormattedTextBlockObjectModal } from './addOrEditFormattedTextBlockObjectModal';
+import { AddOrEditWebPageObjectModal } from './addOrEditWebPageObjectModal';
 import { DashboardPermissionsModal } from './dashboardPermissionsModal';
 import { DashboardPropertiesModal } from './dashboardPropertiesModal';
 import { ScheduleDashboardExportModal } from './scheduleDashboardExportModal';
-import { AppSearch } from '../../models/appSearch';
-import { AddObjectDialog } from '../dialogs/addObjectDialog';
-import { AddOrEditAppSearchObjectModal } from './addOrEditAppSearchObjectModal';
-import { CreateContentLinks } from '../../models/createContentLinks';
-import { AddOrEditCreateContentLinksObjectModal } from './addOrEditCreateContentLinksObjectModal';
-import { DashboardFormattedTextBlock } from '../../models/dashboardFormattedTextBlock';
-import { AddOrEditFormattedTextBlockObjectModal } from './addOrEditFormattedTextBlockObjectModal';
-import { WebPage } from '../../models/webPage';
-import { AddOrEditWebPageObjectModal } from './addOrEditWebPageObjectModal';
-import { DeleteDashboardObjectDialog } from '../dialogs/deleteDashboardObjectDialog';
 
 export class DashboardDesignerModal {
   private readonly page: Page;
@@ -63,7 +64,6 @@ export class DashboardDesignerModal {
     this.webPageObjectModal = new AddOrEditWebPageObjectModal(this.page);
     this.deleteDashboardObjectDialog = new DeleteDashboardObjectDialog(this.page);
   }
-
 
   async waitFor(options?: WaitForOptions) {
     await this.designer.owner().waitFor(options);
@@ -169,43 +169,35 @@ export class DashboardDesignerModal {
     return parseInt(id);
   }
 
-  async addAppSearchObject(appSearchObject: AppSearch) {
+  async addDashboardObject(dashboardObject: DashboardObjectItem) {
     await this.resourcesSection.selectObjectsTab();
-    await this.resourcesSection.clickAddObjectButton('App Search');
+    await this.resourcesSection.clickAddObjectButton(dashboardObject.type);
     await this.addObjectDialog.continueButton.waitFor();
     await this.addObjectDialog.continueButton.click();
-    await this.appSearchObjectModal.fillOutForm(appSearchObject);
-    await this.appSearchObjectModal.save();
+
+    switch (dashboardObject.type) {
+      case 'App Search':
+        await this.appSearchObjectModal.fillOutForm(dashboardObject as AppSearch);
+        await this.appSearchObjectModal.save();
+        break;
+      case 'Create Content Links':
+        await this.createContentLinksObjectModal.fillOutForm(dashboardObject as CreateContentLinks);
+        await this.createContentLinksObjectModal.save();
+        break;
+      case 'Formatted Text Block':
+        await this.formattedTextBlockObjectModal.fillOutForm(dashboardObject as DashboardFormattedTextBlock);
+        await this.formattedTextBlockObjectModal.save();
+        break;
+      case 'Web Page':
+        await this.webPageObjectModal.fillOutForm(dashboardObject as WebPage);
+        await this.webPageObjectModal.save();
+        break;
+      default:
+        throw new Error(`Unknown dashboard object type: ${dashboardObject.type}`);
+    }
   }
 
-  async addCreateContentLinksObject(createContentLinksObject: CreateContentLinks) {
-    await this.resourcesSection.selectObjectsTab();
-    await this.resourcesSection.clickAddObjectButton('Create Content Links');
-    await this.addObjectDialog.continueButton.waitFor();
-    await this.addObjectDialog.continueButton.click();
-    await this.createContentLinksObjectModal.fillOutForm(createContentLinksObject);
-    await this.createContentLinksObjectModal.save();
-  }
-
-  async addFormattedTextBlockObject(formattedTextBlock: DashboardFormattedTextBlock) {
-    await this.resourcesSection.selectObjectsTab();
-    await this.resourcesSection.clickAddObjectButton('Formatted Text Block');
-    await this.addObjectDialog.continueButton.waitFor();
-    await this.addObjectDialog.continueButton.click();
-    await this.formattedTextBlockObjectModal.fillOutForm(formattedTextBlock);
-    await this.formattedTextBlockObjectModal.save();
-  }
-
-  async addWebPageObject(webPageObject: WebPage) {
-    await this.resourcesSection.selectObjectsTab();
-    await this.resourcesSection.clickAddObjectButton('Web Page');
-    await this.addObjectDialog.continueButton.waitFor();
-    await this.addObjectDialog.continueButton.click();
-    await this.webPageObjectModal.fillOutForm(webPageObject);
-    await this.webPageObjectModal.save();
-  }
-
-  async deleteDashboardObject(dashboardObject: DashboardItemObject) {
+  async deleteDashboardObject(dashboardObject: DashboardObjectItem) {
     await this.resourcesSection.selectObjectsTab();
     const item = await this.resourcesSection.getItemFromTab(dashboardObject);
 

--- a/componentObjectModels/modals/dashboardDesignerModal.ts
+++ b/componentObjectModels/modals/dashboardDesignerModal.ts
@@ -11,6 +11,7 @@ import { AddObjectDialog } from '../dialogs/addObjectDialog';
 import { AddOrEditAppSearchObjectModal } from './addOrEditAppSearchObjectModal';
 import { CreateContentLinks } from '../../models/createContentLinks';
 import { AddOrEditCreateContentLinksObjectModal } from './addOrEditCreateContentLinksObjectModal';
+import { DashboardFormattedTextBlock } from '../../models/dashboardFormattedTextBlock';
 
 export class DashboardDesignerModal {
   private readonly page: Page;
@@ -51,6 +52,7 @@ export class DashboardDesignerModal {
     this.addObjectDialog = new AddObjectDialog(this.page);
     this.appSearchObjectModal = new AddOrEditAppSearchObjectModal(this.page);
     this.createContentLinksObjectModal = new AddOrEditCreateContentLinksObjectModal(this.page);
+    this.formattedTextBlockObjectModal = new AddOrEditFormattedTextBlockObjectModal(this.page);
   }
 
 
@@ -174,5 +176,13 @@ export class DashboardDesignerModal {
     await this.addObjectDialog.continueButton.click();
     await this.createContentLinksObjectModal.fillOutForm(createContentLinksObject);
     await this.createContentLinksObjectModal.save();
+  }
+
+  async addFormattedTextBlockObject(formattedTextBlock: DashboardFormattedTextBlock) {
+    await this.resourcesSection.selectObjectsTab();
+    await this.resourcesSection.clickAddObjectButton('Formatted Text Block');
+    await this.addObjectDialog.continueButton.waitFor();
+    await this.addObjectDialog.continueButton.click();
+
   }
 }

--- a/componentObjectModels/modals/dashboardDesignerModal.ts
+++ b/componentObjectModels/modals/dashboardDesignerModal.ts
@@ -9,6 +9,8 @@ import { ScheduleDashboardExportModal } from './scheduleDashboardExportModal';
 import { AppSearch } from '../../models/appSearch';
 import { AddObjectDialog } from '../dialogs/addObjectDialog';
 import { AddOrEditAppSearchObjectModal } from './addOrEditAppSearchObjectModal';
+import { CreateContentLinks } from '../../models/createContentLinks';
+import { AddOrEditCreateContentLinksObjectModal } from './addOrEditCreateContentLinksObjectModal';
 
 export class DashboardDesignerModal {
   private readonly page: Page;
@@ -27,6 +29,7 @@ export class DashboardDesignerModal {
   private readonly canvasSection: DashboardCanvasSection;
   private readonly addObjectDialog: AddObjectDialog;
   private readonly appSearchObjectModal: AddOrEditAppSearchObjectModal;
+  private readonly createContentLinksObjectModal: AddOrEditCreateContentLinksObjectModal;
   readonly title: Locator;
 
   constructor(page: Page) {
@@ -47,7 +50,9 @@ export class DashboardDesignerModal {
     this.canvasSection = new DashboardCanvasSection(this.designer);
     this.addObjectDialog = new AddObjectDialog(this.page);
     this.appSearchObjectModal = new AddOrEditAppSearchObjectModal(this.page);
+    this.createContentLinksObjectModal = new AddOrEditCreateContentLinksObjectModal(this.page);
   }
+
 
   async waitFor(options?: WaitForOptions) {
     await this.designer.owner().waitFor(options);
@@ -160,5 +165,14 @@ export class DashboardDesignerModal {
     await this.addObjectDialog.continueButton.click();
     await this.appSearchObjectModal.fillOutForm(appSearchObject);
     await this.appSearchObjectModal.save();
+  }
+
+  async addCreateContentLinksObject(createContentLinksObject: CreateContentLinks) {
+    await this.resourcesSection.selectObjectsTab();
+    await this.resourcesSection.clickAddObjectButton('Create Content Links');
+    await this.addObjectDialog.continueButton.waitFor();
+    await this.addObjectDialog.continueButton.click();
+    await this.createContentLinksObjectModal.fillOutForm(createContentLinksObject);
+    await this.createContentLinksObjectModal.save();
   }
 }

--- a/componentObjectModels/modals/dashboardDesignerModal.ts
+++ b/componentObjectModels/modals/dashboardDesignerModal.ts
@@ -142,6 +142,29 @@ export class DashboardDesignerModal {
     }
   }
 
+  private async enterAndSaveDashboardObject(dashboardObject: DashboardObjectItem) {
+    switch (dashboardObject.type) {
+      case 'App Search':
+        await this.appSearchObjectModal.fillOutForm(dashboardObject as AppSearch);
+        await this.appSearchObjectModal.save();
+        break;
+      case 'Create Content Links':
+        await this.createContentLinksObjectModal.fillOutForm(dashboardObject as CreateContentLinks);
+        await this.createContentLinksObjectModal.save();
+        break;
+      case 'Formatted Text Block':
+        await this.formattedTextBlockObjectModal.fillOutForm(dashboardObject as DashboardFormattedTextBlock);
+        await this.formattedTextBlockObjectModal.save();
+        break;
+      case 'Web Page':
+        await this.webPageObjectModal.fillOutForm(dashboardObject as WebPage);
+        await this.webPageObjectModal.save();
+        break;
+      default:
+        throw new Error(`Unknown dashboard object type: ${dashboardObject.type}`);
+    }
+  }
+
   async updateDashboard(dashboard: Dashboard) {
     if (dashboard.schedule) {
       await this.updateDashboardScheduling(dashboard.schedule);
@@ -174,27 +197,20 @@ export class DashboardDesignerModal {
     await this.resourcesSection.clickAddObjectButton(dashboardObject.type);
     await this.addObjectDialog.continueButton.waitFor();
     await this.addObjectDialog.continueButton.click();
+    await this.enterAndSaveDashboardObject(dashboardObject);
+  }
 
-    switch (dashboardObject.type) {
-      case 'App Search':
-        await this.appSearchObjectModal.fillOutForm(dashboardObject as AppSearch);
-        await this.appSearchObjectModal.save();
-        break;
-      case 'Create Content Links':
-        await this.createContentLinksObjectModal.fillOutForm(dashboardObject as CreateContentLinks);
-        await this.createContentLinksObjectModal.save();
-        break;
-      case 'Formatted Text Block':
-        await this.formattedTextBlockObjectModal.fillOutForm(dashboardObject as DashboardFormattedTextBlock);
-        await this.formattedTextBlockObjectModal.save();
-        break;
-      case 'Web Page':
-        await this.webPageObjectModal.fillOutForm(dashboardObject as WebPage);
-        await this.webPageObjectModal.save();
-        break;
-      default:
-        throw new Error(`Unknown dashboard object type: ${dashboardObject.type}`);
-    }
+  async updateDashboardObject(
+    existingDashboardObject: DashboardObjectItem,
+    updatedDashboardObject: DashboardObjectItem
+  ) {
+    await this.resourcesSection.selectObjectsTab();
+
+    const item = await this.resourcesSection.getItemFromTab(existingDashboardObject);
+    await item.hover();
+    await item.getByTitle('Edit Object Properties').click();
+
+    await this.enterAndSaveDashboardObject(updatedDashboardObject);
   }
 
   async deleteDashboardObject(dashboardObject: DashboardObjectItem) {

--- a/componentObjectModels/modals/dashboardDesignerModal.ts
+++ b/componentObjectModels/modals/dashboardDesignerModal.ts
@@ -13,6 +13,8 @@ import { CreateContentLinks } from '../../models/createContentLinks';
 import { AddOrEditCreateContentLinksObjectModal } from './addOrEditCreateContentLinksObjectModal';
 import { DashboardFormattedTextBlock } from '../../models/dashboardFormattedTextBlock';
 import { AddOrEditFormattedTextBlockObjectModal } from './addOrEditFormattedTextBlockObjectModal';
+import { WebPage } from '../../models/webPage';
+import { AddOrEditWebPageObjectModal } from './addOrEditWebPageObjectModal';
 
 export class DashboardDesignerModal {
   private readonly page: Page;
@@ -33,6 +35,7 @@ export class DashboardDesignerModal {
   private readonly appSearchObjectModal: AddOrEditAppSearchObjectModal;
   private readonly createContentLinksObjectModal: AddOrEditCreateContentLinksObjectModal;
   private readonly formattedTextBlockObjectModal: AddOrEditFormattedTextBlockObjectModal;
+  private readonly webPageObjectModal: AddOrEditWebPageObjectModal;
   readonly title: Locator;
 
   constructor(page: Page) {
@@ -55,6 +58,7 @@ export class DashboardDesignerModal {
     this.appSearchObjectModal = new AddOrEditAppSearchObjectModal(this.page);
     this.createContentLinksObjectModal = new AddOrEditCreateContentLinksObjectModal(this.page);
     this.formattedTextBlockObjectModal = new AddOrEditFormattedTextBlockObjectModal(this.page);
+    this.webPageObjectModal = new AddOrEditWebPageObjectModal(this.page);
   }
 
 
@@ -187,6 +191,14 @@ export class DashboardDesignerModal {
     await this.addObjectDialog.continueButton.click();
     await this.formattedTextBlockObjectModal.fillOutForm(formattedTextBlock);
     await this.formattedTextBlockObjectModal.save();
+  }
 
+  async addWebPageObject(webPageObject: WebPage) {
+    await this.resourcesSection.selectObjectsTab();
+    await this.resourcesSection.clickAddObjectButton('Web Page');
+    await this.addObjectDialog.continueButton.waitFor();
+    await this.addObjectDialog.continueButton.click();
+    await this.webPageObjectModal.fillOutForm(webPageObject);
+    await this.webPageObjectModal.save();
   }
 }

--- a/componentObjectModels/sections/baseLayoutItemsSection.ts
+++ b/componentObjectModels/sections/baseLayoutItemsSection.ts
@@ -1,15 +1,17 @@
 import { FrameLocator, Locator } from '@playwright/test';
 
 export class BaseLayoutItemsSection {
+  protected readonly frame: FrameLocator;
   protected readonly section: Locator;
   protected readonly tabsContainer: Locator;
 
-  protected getTabButton(tabName: string) {
-    return this.tabsContainer.getByRole('tab', { name: tabName });
-  }
-
   constructor(frame: FrameLocator) {
+    this.frame = frame;
     this.section = frame.locator('.item-container').first();
     this.tabsContainer = this.section.locator('#tabstrip-container');
+  }
+
+  protected getTabButton(tabName: string) {
+    return this.tabsContainer.getByRole('tab', { name: tabName });
   }
 }

--- a/componentObjectModels/sections/dashboardResourcesSection.ts
+++ b/componentObjectModels/sections/dashboardResourcesSection.ts
@@ -2,12 +2,9 @@ import { FrameLocator, Locator } from '@playwright/test';
 import { SavedReport } from '../../models/report';
 import { DashboardDesignerReportsTab } from '../tabs/dashboardDesignerReportsTab';
 import { BaseLayoutItemsSection } from './baseLayoutItemsSection';
-import { AppSearch } from '../../models/appSearch';
 import { DashboardDesignerObjectsTab } from '../tabs/dashboardDesignerObjectsTab';
-import { CreateContentLinks } from '../../models/createContentLinks';
-import { DashboardFormattedTextBlock } from '../../models/dashboardFormattedTextBlock';
-import { WebPage } from '../../models/webPage';
 import { DashboardItem } from '../../models/dashboard';
+import { DashboardObjectItem } from '../../models/dashboardObjectItem';
 
 type ObjectName = 'App Search' | 'Create Content Links' | 'Formatted Text Block' | 'Web Page';
 
@@ -60,26 +57,22 @@ export class DashboardResourcesSection extends BaseLayoutItemsSection {
       return this.reportsTab.getReportFromBank(item.name);
     }
 
-    if (item instanceof AppSearch) {
+    if (item instanceof DashboardObjectItem) {
       await this.ensureItemTabSelected(this.objectsTabButton);
-      return this.objectsTab.getObjectFromBank(item.name);
-    }
-
-    if (item instanceof CreateContentLinks) {
-      await this.ensureItemTabSelected(this.objectsTabButton);
-      return this.objectsTab.getObjectFromBank(item.name);
-    }
-
-    if (item instanceof DashboardFormattedTextBlock) {
-      await this.ensureItemTabSelected(this.objectsTabButton);
-      return this.objectsTab.getObjectFromBank(item.name);
-    }
-
-    if (item instanceof WebPage) {
-      await this.ensureItemTabSelected(this.objectsTabButton);
-      return this.objectsTab.getObjectFromBank(item.name);
+      const object = await this.objectsTab.getObjectFromBank(item.name);
+      return object;
     }
 
     throw new Error(`Item type not supported: ${item.constructor.name}`);
+  }
+
+
+  async getItemFromTabByName(TEST_DASHBOARD_OBJECT_NAME: string) {
+    await this.ensureItemTabSelected(this.objectsTabButton);
+    return await this.objectsTab.getObjectFromBank(TEST_DASHBOARD_OBJECT_NAME);
+  }
+
+  async scrollAllObjectsIntoView() {
+    return this.objectsTab.scrollAllItemsIntoView();
   }
 }

--- a/componentObjectModels/sections/dashboardResourcesSection.ts
+++ b/componentObjectModels/sections/dashboardResourcesSection.ts
@@ -1,5 +1,4 @@
 import { FrameLocator, Locator } from '@playwright/test';
-import { DashboardItem } from '../../models/dashboard';
 import { SavedReport } from '../../models/report';
 import { DashboardDesignerReportsTab } from '../tabs/dashboardDesignerReportsTab';
 import { BaseLayoutItemsSection } from './baseLayoutItemsSection';
@@ -8,6 +7,7 @@ import { DashboardDesignerObjectsTab } from '../tabs/dashboardDesignerObjectsTab
 import { CreateContentLinks } from '../../models/createContentLinks';
 import { DashboardFormattedTextBlock } from '../../models/dashboardFormattedTextBlock';
 import { WebPage } from '../../models/webPage';
+import { DashboardItem } from '../../models/dashboard';
 
 type ObjectName = 'App Search' | 'Create Content Links' | 'Formatted Text Block' | 'Web Page';
 
@@ -53,31 +53,31 @@ export class DashboardResourcesSection extends BaseLayoutItemsSection {
   }
 
   async getItemFromTab(item: DashboardItem) {
-    if (item.object instanceof SavedReport) {
+    if (item instanceof SavedReport) {
       await this.ensureItemTabSelected(this.reportTabButton);
-      return this.reportsTab.getReportFromBank(item.object.name);
+      return this.reportsTab.getReportFromBank(item.name);
     }
 
-    if (item.object instanceof AppSearch) {
+    if (item instanceof AppSearch) {
       await this.ensureItemTabSelected(this.objectsTabButton);
-      return this.objectsTab.getObjectFromBank(item.object.name);
+      return this.objectsTab.getObjectFromBank(item.name);
     }
 
-    if (item.object instanceof CreateContentLinks) {
+    if (item instanceof CreateContentLinks) {
       await this.ensureItemTabSelected(this.objectsTabButton);
-      return this.objectsTab.getObjectFromBank(item.object.name);
+      return this.objectsTab.getObjectFromBank(item.name);
     }
 
-    if (item.object instanceof DashboardFormattedTextBlock) {
+    if (item instanceof DashboardFormattedTextBlock) {
       await this.ensureItemTabSelected(this.objectsTabButton);
-      return this.objectsTab.getObjectFromBank(item.object.name);
+      return this.objectsTab.getObjectFromBank(item.name);
     }
 
-    if (item.object instanceof WebPage) {
+    if (item instanceof WebPage) {
       await this.ensureItemTabSelected(this.objectsTabButton);
-      return this.objectsTab.getObjectFromBank(item.object.name);
+      return this.objectsTab.getObjectFromBank(item.name);
     }
 
-    throw new Error(`Item type not supported: ${item.object.constructor.name}`);
+    throw new Error(`Item type not supported: ${item.constructor.name}`);
   }
 }

--- a/componentObjectModels/sections/dashboardResourcesSection.ts
+++ b/componentObjectModels/sections/dashboardResourcesSection.ts
@@ -7,6 +7,7 @@ import { AppSearch } from '../../models/appSearch';
 import { DashboardDesignerObjectsTab } from '../tabs/dashboardDesignerObjectsTab';
 import { CreateContentLinks } from '../../models/createContentLinks';
 import { DashboardFormattedTextBlock } from '../../models/dashboardFormattedTextBlock';
+import { WebPage } from '../../models/webPage';
 
 type ObjectName = 'App Search' | 'Create Content Links' | 'Formatted Text Block' | 'Web Page';
 
@@ -68,6 +69,11 @@ export class DashboardResourcesSection extends BaseLayoutItemsSection {
     }
 
     if (item.object instanceof DashboardFormattedTextBlock) {
+      await this.ensureItemTabSelected(this.objectsTabButton);
+      return this.objectsTab.getObjectFromBank(item.object.name);
+    }
+
+    if (item.object instanceof WebPage) {
       await this.ensureItemTabSelected(this.objectsTabButton);
       return this.objectsTab.getObjectFromBank(item.object.name);
     }

--- a/componentObjectModels/sections/dashboardResourcesSection.ts
+++ b/componentObjectModels/sections/dashboardResourcesSection.ts
@@ -3,14 +3,20 @@ import { DashboardItem } from '../../models/dashboard';
 import { SavedReport } from '../../models/report';
 import { DashboardDesignerReportsTab } from '../tabs/dashboardDesignerReportsTab';
 import { BaseLayoutItemsSection } from './baseLayoutItemsSection';
+import { AppSearch } from '../../models/appSearch';
+import { DashboardDesignerObjectsTab } from '../tabs/dashboardDesignerObjectsTab';
+
+type ObjectName = 'App Search' | 'Create Content Links' | 'Formatted Text Block' | 'Web Page';
 
 export class DashboardResourcesSection extends BaseLayoutItemsSection {
   private readonly reportTabButton: Locator;
   private readonly keyMetricTabButton: Locator;
   private readonly layoutsTabButton: Locator;
   private readonly objectsTabButton: Locator;
-
+  private readonly addObjectButton: Locator;
+  private readonly addObjectMenu: Locator;
   private readonly reportsTab: DashboardDesignerReportsTab;
+  private readonly objectsTab: DashboardDesignerObjectsTab;
 
   constructor(frame: FrameLocator) {
     super(frame);
@@ -18,7 +24,10 @@ export class DashboardResourcesSection extends BaseLayoutItemsSection {
     this.keyMetricTabButton = this.getTabButton('Key Metrics');
     this.layoutsTabButton = this.getTabButton('Layouts');
     this.objectsTabButton = this.getTabButton('Objects');
+    this.addObjectButton = this.section.getByTitle('Add Object');
+    this.addObjectMenu = this.frame.locator('[data-add-menu="object"]');
     this.reportsTab = new DashboardDesignerReportsTab(frame);
+    this.objectsTab = new DashboardDesignerObjectsTab(frame);
   }
 
   private async ensureItemTabSelected(tabButton: Locator) {
@@ -30,10 +39,25 @@ export class DashboardResourcesSection extends BaseLayoutItemsSection {
     }
   }
 
+  async selectObjectsTab() {
+    await this.ensureItemTabSelected(this.objectsTabButton);
+  }
+
+  async clickAddObjectButton(objectName: ObjectName) {
+    await this.addObjectButton.click();
+    await this.addObjectMenu.waitFor();
+    await this.addObjectMenu.getByText(objectName).click();
+  }
+
   async getItemFromTab(item: DashboardItem) {
     if (item.object instanceof SavedReport) {
       await this.ensureItemTabSelected(this.reportTabButton);
       return this.reportsTab.getReportFromBank(item.object.name);
+    }
+
+    if (item.object instanceof AppSearch) {
+      await this.ensureItemTabSelected(this.objectsTabButton);
+      return this.objectsTab.getObjectFromBank(item.object.name);
     }
 
     throw new Error(`Item type not supported: ${item.object.constructor.name}`);

--- a/componentObjectModels/sections/dashboardResourcesSection.ts
+++ b/componentObjectModels/sections/dashboardResourcesSection.ts
@@ -66,7 +66,6 @@ export class DashboardResourcesSection extends BaseLayoutItemsSection {
     throw new Error(`Item type not supported: ${item.constructor.name}`);
   }
 
-
   async getItemFromTabByName(TEST_DASHBOARD_OBJECT_NAME: string) {
     await this.ensureItemTabSelected(this.objectsTabButton);
     return await this.objectsTab.getObjectFromBank(TEST_DASHBOARD_OBJECT_NAME);

--- a/componentObjectModels/sections/dashboardResourcesSection.ts
+++ b/componentObjectModels/sections/dashboardResourcesSection.ts
@@ -6,6 +6,7 @@ import { BaseLayoutItemsSection } from './baseLayoutItemsSection';
 import { AppSearch } from '../../models/appSearch';
 import { DashboardDesignerObjectsTab } from '../tabs/dashboardDesignerObjectsTab';
 import { CreateContentLinks } from '../../models/createContentLinks';
+import { DashboardFormattedTextBlock } from '../../models/dashboardFormattedTextBlock';
 
 type ObjectName = 'App Search' | 'Create Content Links' | 'Formatted Text Block' | 'Web Page';
 
@@ -62,6 +63,11 @@ export class DashboardResourcesSection extends BaseLayoutItemsSection {
     }
 
     if (item.object instanceof CreateContentLinks) {
+      await this.ensureItemTabSelected(this.objectsTabButton);
+      return this.objectsTab.getObjectFromBank(item.object.name);
+    }
+
+    if (item.object instanceof DashboardFormattedTextBlock) {
       await this.ensureItemTabSelected(this.objectsTabButton);
       return this.objectsTab.getObjectFromBank(item.object.name);
     }

--- a/componentObjectModels/sections/dashboardResourcesSection.ts
+++ b/componentObjectModels/sections/dashboardResourcesSection.ts
@@ -34,6 +34,8 @@ export class DashboardResourcesSection extends BaseLayoutItemsSection {
   }
 
   private async ensureItemTabSelected(tabButton: Locator) {
+    await tabButton.waitFor();
+
     const tabSelected = await tabButton.getAttribute('aria-selected');
     const isTabSelected = tabSelected === 'true';
 

--- a/componentObjectModels/sections/dashboardResourcesSection.ts
+++ b/componentObjectModels/sections/dashboardResourcesSection.ts
@@ -5,6 +5,7 @@ import { DashboardDesignerReportsTab } from '../tabs/dashboardDesignerReportsTab
 import { BaseLayoutItemsSection } from './baseLayoutItemsSection';
 import { AppSearch } from '../../models/appSearch';
 import { DashboardDesignerObjectsTab } from '../tabs/dashboardDesignerObjectsTab';
+import { CreateContentLinks } from '../../models/createContentLinks';
 
 type ObjectName = 'App Search' | 'Create Content Links' | 'Formatted Text Block' | 'Web Page';
 
@@ -56,6 +57,11 @@ export class DashboardResourcesSection extends BaseLayoutItemsSection {
     }
 
     if (item.object instanceof AppSearch) {
+      await this.ensureItemTabSelected(this.objectsTabButton);
+      return this.objectsTab.getObjectFromBank(item.object.name);
+    }
+
+    if (item.object instanceof CreateContentLinks) {
       await this.ensureItemTabSelected(this.objectsTabButton);
       return this.objectsTab.getObjectFromBank(item.object.name);
     }

--- a/componentObjectModels/tabs/dashboardDesignerObjectsTab.ts
+++ b/componentObjectModels/tabs/dashboardDesignerObjectsTab.ts
@@ -1,0 +1,12 @@
+import { FrameLocator } from '@playwright/test';
+import { BaseDashboardDesignerTab } from './baseDashboardDesignerTab';
+
+export class DashboardDesignerObjectsTab extends BaseDashboardDesignerTab {
+  constructor(frame: FrameLocator) {
+    super(frame);
+  }
+
+  getObjectFromBank(objectName: string) {
+    return this.getItemFromBank('object', objectName);
+  }
+}

--- a/componentObjectModels/tabs/dashboardDesignerObjectsTab.ts
+++ b/componentObjectModels/tabs/dashboardDesignerObjectsTab.ts
@@ -1,12 +1,64 @@
-import { FrameLocator } from '@playwright/test';
+import { FrameLocator, Locator } from '@playwright/test';
 import { BaseDashboardDesignerTab } from './baseDashboardDesignerTab';
 
 export class DashboardDesignerObjectsTab extends BaseDashboardDesignerTab {
+  private readonly getMoreObjetsPathRegex: RegExp;
+
   constructor(frame: FrameLocator) {
     super(frame);
+
+    this.getMoreObjetsPathRegex = /\/Admin\/Dashboard\/GetMoreObjectListItems/;
   }
 
-  getObjectFromBank(objectName: string) {
-    return this.getItemFromBank('object', objectName);
+  private async isScrolledToBottom(scrollableElement: Locator) {
+    return await scrollableElement.evaluate(el => {
+      const scrollTop = el.scrollTop;
+      const scrollHeight = el.scrollHeight;
+      const clientHeight = el.clientHeight;
+
+      return Math.abs(scrollHeight - clientHeight - scrollTop) < 1;
+    });
+  }
+
+  async getObjectFromBank(objectName: string) {
+    const scrollableElement = this.frame.locator('[data-tab-content="object"]').locator('.item-lists');
+    const hasScrollbar = await scrollableElement.evaluate(el => el.scrollHeight > el.clientHeight);
+    const item = this.getItemFromBank('object', objectName);
+
+    if (hasScrollbar === false) {
+      return item;
+    }
+
+    do {
+      if (await item.isVisible()) {
+        break;
+      }
+
+      const scrollResponse = scrollableElement.page().waitForResponse(this.getMoreObjetsPathRegex);
+      await scrollableElement.evaluate(el => (el.scrollTop = el.scrollHeight));
+      await scrollResponse;
+    } while ((await this.isScrolledToBottom(scrollableElement)) === false);
+
+    return item;
+  }
+
+  async scrollAllItemsIntoView() {
+    const scrollableElement = this.frame.locator('[data-tab-content="object"]').locator('.item-lists');
+    const hasScrollbar = await scrollableElement.evaluate(el => el.scrollHeight > el.clientHeight);
+
+    if (hasScrollbar === false) {
+      return;
+    }
+
+    do {
+      const scrollResponse = scrollableElement.page().waitForResponse(this.getMoreObjetsPathRegex);
+      await scrollableElement.evaluate(el => (el.scrollTop = el.scrollHeight));
+
+      if (await this.isScrolledToBottom(scrollableElement)) {
+        break;
+      }
+
+      await scrollResponse;
+    } while ((await this.isScrolledToBottom(scrollableElement)) === false);
   }
 }

--- a/factories/fakeDataFactory.ts
+++ b/factories/fakeDataFactory.ts
@@ -15,6 +15,7 @@ export const TEST_LIST_NAME = 'list-test';
 export const TEST_SENDING_NUMBER_NAME = 'sending-number-test';
 export const TEST_CONNECTOR_NAME = 'connector-test';
 export const TEST_DASHBOARD_NAME = 'dashboard-test';
+export const TEST_DASHBOARD_OBJECT_NAME = 'object-test';
 
 export class FakeDataFactory {
   static createUniqueIdentifier() {
@@ -25,7 +26,7 @@ export class FakeDataFactory {
 
   static createFakeObjectName() {
     const uniqueId = this.createUniqueIdentifier();
-    return `${uniqueId}-object`;
+    return `${uniqueId}-${TEST_DASHBOARD_OBJECT_NAME}`;
   }
 
   static createFakeDashboardName() {

--- a/factories/fakeDataFactory.ts
+++ b/factories/fakeDataFactory.ts
@@ -23,6 +23,11 @@ export class FakeDataFactory {
     return `${timestamp}-${id}`;
   }
 
+  static createFakeObjectName() {
+    const uniqueId = this.createUniqueIdentifier();
+    return `${uniqueId}-object`;
+  }
+
   static createFakeDashboardName() {
     const uniqueId = this.createUniqueIdentifier();
     return `${uniqueId}-${TEST_DASHBOARD_NAME}`;

--- a/fixtures/dashboard.fixtures.ts
+++ b/fixtures/dashboard.fixtures.ts
@@ -1,0 +1,28 @@
+import { Page } from '@playwright/test';
+import { DashboardsAdminPage } from '../pageObjectModels/dashboards/dashboardsAdminPage';
+import { Dashboard } from '../models/dashboard';
+
+export async function createDashboardFixture(
+  { sysAdminPage, dashboard }: { sysAdminPage: Page; dashboard: Dashboard },
+  use: (r: Dashboard) => Promise<void>
+) {
+  const { dashboard: newDashboard, cleanup } = await createDashboard(sysAdminPage, dashboard);
+  await use(newDashboard);
+  await cleanup();
+}
+
+async function createDashboard(sysAdminPage: Page, dashboard: Dashboard) {
+  const dashboardsAdminPage = new DashboardsAdminPage(sysAdminPage);
+
+  await dashboardsAdminPage.goto();
+  await dashboardsAdminPage.createDashboard(dashboard);
+  await dashboardsAdminPage.dashboardDesigner.updateDashboard(dashboard);
+  await dashboardsAdminPage.dashboardDesigner.saveAndClose();
+
+  async function cleanup() {
+    await dashboardsAdminPage.goto();
+    await dashboardsAdminPage.deleteDashboards([dashboard.name]);
+  }
+
+  return { dashboard, cleanup };
+}

--- a/models/appSearch.ts
+++ b/models/appSearch.ts
@@ -1,29 +1,16 @@
-type ViewSecurity = 'Public' | 'Private by Role';
+import { DashboardObjectItem, DashboardObjectItemObject } from './dashboardObjectItem';
 
-type AppSearchObject = {
-  name: string;
+type AppSearchObject = Omit<DashboardObjectItemObject, 'type'> & {
   apps: string[];
-  hideHeader?: boolean;
-  hideContainer?: boolean;
-  view?: ViewSecurity;
-  roles?: string[];
 };
 
-export class AppSearch {
-  name: string;
+export class AppSearch extends DashboardObjectItem {
   apps: string[];
-  hideHeader: boolean;
-  hideContainer: boolean;
-  view: ViewSecurity;
-  roles: string[];
 
   constructor({ name, apps, hideHeader = false, hideContainer = false, view = 'Public', roles = [] }: AppSearchObject) {
-    this.name = name;
+    super({ name, type: 'App Search', hideHeader, hideContainer, view, roles });
+    
     this.apps = apps;
-    this.hideHeader = hideHeader;
-    this.hideContainer = hideContainer;
-    this.view = view;
-    this.roles = roles;
 
     if (this.apps.length === 0) {
       throw new Error('App Search object must have at least one app');

--- a/models/appSearch.ts
+++ b/models/appSearch.ts
@@ -16,4 +16,15 @@ export class AppSearch extends DashboardObjectItem {
       throw new Error('App Search object must have at least one app');
     }
   }
+
+  clone() {
+    return new AppSearch({
+      name: this.name,
+      apps: [...this.apps],
+      hideHeader: this.hideHeader,
+      hideContainer: this.hideContainer,
+      view: this.view,
+      roles: [...this.roles],
+    });
+  }
 }

--- a/models/appSearch.ts
+++ b/models/appSearch.ts
@@ -1,0 +1,32 @@
+type ViewSecurity = 'Public' | 'Private by Role';
+
+type AppSearchObject = {
+  name: string;
+  apps: string[];
+  hideHeader?: boolean;
+  hideContainer?: boolean;
+  view?: ViewSecurity;
+  roles?: string[];
+};
+
+export class AppSearch {
+  name: string;
+  apps: string[];
+  hideHeader: boolean;
+  hideContainer: boolean;
+  view: ViewSecurity;
+  roles: string[];
+
+  constructor({ name, apps, hideHeader = false, hideContainer = false, view = 'Public', roles = [] }: AppSearchObject) {
+    this.name = name;
+    this.apps = apps;
+    this.hideHeader = hideHeader;
+    this.hideContainer = hideContainer;
+    this.view = view;
+    this.roles = roles;
+
+    if (this.apps.length === 0) {
+      throw new Error('App Search object must have at least one app');
+    }
+  }
+}

--- a/models/appSearch.ts
+++ b/models/appSearch.ts
@@ -9,7 +9,7 @@ export class AppSearch extends DashboardObjectItem {
 
   constructor({ name, apps, hideHeader = false, hideContainer = false, view = 'Public', roles = [] }: AppSearchObject) {
     super({ name, type: 'App Search', hideHeader, hideContainer, view, roles });
-    
+
     this.apps = apps;
 
     if (this.apps.length === 0) {

--- a/models/createContentLinks.ts
+++ b/models/createContentLinks.ts
@@ -1,27 +1,18 @@
+import { DashboardObjectItem, DashboardObjectItemObject } from "./dashboardObjectItem";
+
 type Link = {
   app: string;
   imageSource: { src: 'None' } | { src: 'App' } | { src: 'Library'; imageName: string };
   linkText: string;
 };
 
-type ViewSecurity = 'Public' | 'Private by Role';
 
-type CreateContentLinksObject = {
-  name: string;
+type CreateContentLinksObject = Omit<DashboardObjectItemObject, 'type'> & {
   links: Link[];
-  hideHeader?: boolean;
-  hideContainer?: boolean;
-  view?: ViewSecurity;
-  roles?: string[];
 };
 
-export class CreateContentLinks {
-  name: string;
+export class CreateContentLinks extends DashboardObjectItem {
   links: Link[];
-  hideHeader: boolean;
-  hideContainer: boolean;
-  view: ViewSecurity;
-  roles: string[];
 
   constructor({
     name,
@@ -31,12 +22,9 @@ export class CreateContentLinks {
     view = 'Public',
     roles = [],
   }: CreateContentLinksObject) {
-    this.name = name;
+    super({ name, type: 'Create Content Links', hideHeader, hideContainer, view, roles });
+
     this.links = links;
-    this.hideHeader = hideHeader;
-    this.hideContainer = hideContainer;
-    this.view = view;
-    this.roles = roles;
 
     if (this.links.length === 0) {
       throw new Error('Links must not be empty');

--- a/models/createContentLinks.ts
+++ b/models/createContentLinks.ts
@@ -1,11 +1,10 @@
-import { DashboardObjectItem, DashboardObjectItemObject } from "./dashboardObjectItem";
+import { DashboardObjectItem, DashboardObjectItemObject } from './dashboardObjectItem';
 
 type Link = {
   app: string;
   imageSource: { src: 'None' } | { src: 'App' } | { src: 'Library'; imageName: string };
   linkText: string;
 };
-
 
 type CreateContentLinksObject = Omit<DashboardObjectItemObject, 'type'> & {
   links: Link[];

--- a/models/createContentLinks.ts
+++ b/models/createContentLinks.ts
@@ -29,4 +29,15 @@ export class CreateContentLinks extends DashboardObjectItem {
       throw new Error('Links must not be empty');
     }
   }
+
+  clone() {
+    return new CreateContentLinks({
+      name: this.name,
+      links: [...this.links],
+      hideHeader: this.hideHeader,
+      hideContainer: this.hideContainer,
+      view: this.view,
+      roles: [...this.roles],
+    });
+  }
 }

--- a/models/createContentLinks.ts
+++ b/models/createContentLinks.ts
@@ -1,0 +1,45 @@
+type Link = {
+  app: string;
+  imageSource: { src: 'None' } | { src: 'App' } | { src: 'Library'; imageName: string };
+  linkText: string;
+};
+
+type ViewSecurity = 'Public' | 'Private by Role';
+
+type CreateContentLinksObject = {
+  name: string;
+  links: Link[];
+  hideHeader?: boolean;
+  hideContainer?: boolean;
+  view?: ViewSecurity;
+  roles?: string[];
+};
+
+export class CreateContentLinks {
+  name: string;
+  links: Link[];
+  hideHeader: boolean;
+  hideContainer: boolean;
+  view: ViewSecurity;
+  roles: string[];
+
+  constructor({
+    name,
+    links,
+    hideHeader = false,
+    hideContainer = false,
+    view = 'Public',
+    roles = [],
+  }: CreateContentLinksObject) {
+    this.name = name;
+    this.links = links;
+    this.hideHeader = hideHeader;
+    this.hideContainer = hideContainer;
+    this.view = view;
+    this.roles = roles;
+
+    if (this.links.length === 0) {
+      throw new Error('Links must not be empty');
+    }
+  }
+}

--- a/models/dashboard.ts
+++ b/models/dashboard.ts
@@ -1,8 +1,9 @@
+import { AppSearch } from './appSearch';
 import { ExportDashboardOptions } from './exportDashboardOptions';
 import { Report, ScheduledExportCustomSchedule, ScheduledExportFrequency } from './report';
 
 export type DashboardItem = {
-  object: Report;
+  object: Report | AppSearch;
   row: number;
   column: number;
 };

--- a/models/dashboard.ts
+++ b/models/dashboard.ts
@@ -1,13 +1,8 @@
-import { AppSearch } from './appSearch';
-import { CreateContentLinks } from './createContentLinks';
-import { DashboardFormattedTextBlock } from './dashboardFormattedTextBlock';
+import { DashboardObjectItem } from './dashboardObjectItem';
 import { ExportDashboardOptions } from './exportDashboardOptions';
 import { Report, ScheduledExportCustomSchedule, ScheduledExportFrequency } from './report';
-import { WebPage } from './webPage';
 
-export type DashboardItemObject = AppSearch | CreateContentLinks | DashboardFormattedTextBlock | WebPage;
-
-export type DashboardItem = Report | DashboardObject;
+export type DashboardItem = Report | DashboardObjectItem;
 
 export type DashboardItemWithLocation = {
   item: DashboardItem;

--- a/models/dashboard.ts
+++ b/models/dashboard.ts
@@ -5,8 +5,12 @@ import { ExportDashboardOptions } from './exportDashboardOptions';
 import { Report, ScheduledExportCustomSchedule, ScheduledExportFrequency } from './report';
 import { WebPage } from './webPage';
 
-export type DashboardItem = {
-  object: Report | AppSearch | CreateContentLinks | DashboardFormattedTextBlock | WebPage;
+export type DashboardItemObject = AppSearch | CreateContentLinks | DashboardFormattedTextBlock | WebPage;
+
+export type DashboardItem = Report | DashboardObject;
+
+export type DashboardItemWithLocation = {
+  item: DashboardItem;
   row: number;
   column: number;
 };
@@ -120,7 +124,7 @@ type DashboardObject = {
   title?: DashboardTitle;
   status?: boolean;
   containers?: string[];
-  items?: DashboardItem[];
+  items?: DashboardItemWithLocation[];
   schedule?: DashboardSchedule;
   permissionStatus?: 'Public' | 'Private';
   permissions?: DashboardPermissions;
@@ -133,7 +137,7 @@ export class Dashboard {
   title: DashboardTitle;
   status: boolean;
   containers: string[];
-  items: DashboardItem[];
+  items: DashboardItemWithLocation[];
   schedule?: DashboardSchedule;
   permissionStatus: 'Public' | 'Private';
   permissions: {

--- a/models/dashboard.ts
+++ b/models/dashboard.ts
@@ -3,9 +3,10 @@ import { CreateContentLinks } from './createContentLinks';
 import { DashboardFormattedTextBlock } from './dashboardFormattedTextBlock';
 import { ExportDashboardOptions } from './exportDashboardOptions';
 import { Report, ScheduledExportCustomSchedule, ScheduledExportFrequency } from './report';
+import { WebPage } from './webPage';
 
 export type DashboardItem = {
-  object: Report | AppSearch | CreateContentLinks | DashboardFormattedTextBlock;
+  object: Report | AppSearch | CreateContentLinks | DashboardFormattedTextBlock | WebPage;
   row: number;
   column: number;
 };

--- a/models/dashboard.ts
+++ b/models/dashboard.ts
@@ -1,9 +1,10 @@
 import { AppSearch } from './appSearch';
+import { CreateContentLinks } from './createContentLinks';
 import { ExportDashboardOptions } from './exportDashboardOptions';
 import { Report, ScheduledExportCustomSchedule, ScheduledExportFrequency } from './report';
 
 export type DashboardItem = {
-  object: Report | AppSearch;
+  object: Report | AppSearch | CreateContentLinks;
   row: number;
   column: number;
 };

--- a/models/dashboard.ts
+++ b/models/dashboard.ts
@@ -1,10 +1,11 @@
 import { AppSearch } from './appSearch';
 import { CreateContentLinks } from './createContentLinks';
+import { DashboardFormattedTextBlock } from './dashboardFormattedTextBlock';
 import { ExportDashboardOptions } from './exportDashboardOptions';
 import { Report, ScheduledExportCustomSchedule, ScheduledExportFrequency } from './report';
 
 export type DashboardItem = {
-  object: Report | AppSearch | CreateContentLinks;
+  object: Report | AppSearch | CreateContentLinks | DashboardFormattedTextBlock;
   row: number;
   column: number;
 };

--- a/models/dashboardFormattedTextBlock.ts
+++ b/models/dashboardFormattedTextBlock.ts
@@ -1,0 +1,35 @@
+type ViewSecurity = 'Public' | 'Private by Role';
+
+type DashboardFormattedTextBlockObject = {
+  name: string;
+  formattedText?: string;
+  hideHeader?: boolean;
+  hideContainer?: boolean;
+  view?: ViewSecurity;
+  roles?: string[];
+};
+
+export class DashboardFormattedTextBlock {
+  name: string;
+  formattedText: string;
+  hideHeader: boolean;
+  hideContainer: boolean;
+  view: ViewSecurity;
+  roles: string[];
+
+  constructor({
+    name,
+    formattedText = '',
+    hideHeader = false,
+    hideContainer = false,
+    view = 'Public',
+    roles = [],
+  }: DashboardFormattedTextBlockObject) {
+    this.name = name;
+    this.formattedText = formattedText;
+    this.hideHeader = hideHeader;
+    this.hideContainer = hideContainer;
+    this.view = view;
+    this.roles = roles;
+  }
+}

--- a/models/dashboardFormattedTextBlock.ts
+++ b/models/dashboardFormattedTextBlock.ts
@@ -26,4 +26,15 @@ export class DashboardFormattedTextBlock extends DashboardObjectItem {
 
     this.formattedText = formattedText;
   }
+
+  clone() {
+    return new DashboardFormattedTextBlock({
+      name: this.name,
+      formattedText: this.formattedText,
+      hideHeader: this.hideHeader,
+      hideContainer: this.hideContainer,
+      view: this.view,
+      roles: [...this.roles],
+    });
+  }
 }

--- a/models/dashboardFormattedTextBlock.ts
+++ b/models/dashboardFormattedTextBlock.ts
@@ -1,21 +1,11 @@
-type ViewSecurity = 'Public' | 'Private by Role';
+import { DashboardObjectItem, DashboardObjectItemObject } from './dashboardObjectItem';
 
-type DashboardFormattedTextBlockObject = {
-  name: string;
+type DashboardFormattedTextBlockObject = Omit<DashboardObjectItemObject, 'type'> & {
   formattedText?: string;
-  hideHeader?: boolean;
-  hideContainer?: boolean;
-  view?: ViewSecurity;
-  roles?: string[];
 };
 
-export class DashboardFormattedTextBlock {
-  name: string;
+export class DashboardFormattedTextBlock extends DashboardObjectItem {
   formattedText: string;
-  hideHeader: boolean;
-  hideContainer: boolean;
-  view: ViewSecurity;
-  roles: string[];
 
   constructor({
     name,
@@ -25,11 +15,15 @@ export class DashboardFormattedTextBlock {
     view = 'Public',
     roles = [],
   }: DashboardFormattedTextBlockObject) {
-    this.name = name;
+    super({
+      name,
+      type: 'Formatted Text Block',
+      hideHeader,
+      hideContainer,
+      view,
+      roles,
+    });
+
     this.formattedText = formattedText;
-    this.hideHeader = hideHeader;
-    this.hideContainer = hideContainer;
-    this.view = view;
-    this.roles = roles;
   }
 }

--- a/models/dashboardObjectItem.ts
+++ b/models/dashboardObjectItem.ts
@@ -34,4 +34,6 @@ export abstract class DashboardObjectItem {
     this.view = view;
     this.roles = roles;
   }
+
+  abstract clone(): DashboardObjectItem;
 }

--- a/models/dashboardObjectItem.ts
+++ b/models/dashboardObjectItem.ts
@@ -1,0 +1,37 @@
+type DashboardObjectItemType = 'App Search' | 'Create Content Links' | 'Formatted Text Block' | 'Web Page';
+
+type DashboardObjectItemViewSecurity = 'Public' | 'Private by Role';
+
+export type DashboardObjectItemObject = {
+  name: string;
+  type: DashboardObjectItemType;
+  hideHeader?: boolean;
+  hideContainer?: boolean;
+  view?: DashboardObjectItemViewSecurity;
+  roles?: string[];
+};
+
+export abstract class DashboardObjectItem {
+  name: string;
+  type: DashboardObjectItemType;
+  hideHeader: boolean;
+  hideContainer: boolean;
+  view: DashboardObjectItemViewSecurity;
+  roles: string[];
+
+  constructor({
+    name,
+    type,
+    hideHeader = false,
+    hideContainer = false,
+    view = 'Public',
+    roles = [],
+  }: DashboardObjectItemObject) {
+    this.name = name;
+    this.type = type;
+    this.hideHeader = hideHeader;
+    this.hideContainer = hideContainer;
+    this.view = view;
+    this.roles = roles;
+  }
+}

--- a/models/webPage.ts
+++ b/models/webPage.ts
@@ -1,23 +1,13 @@
-type ViewSecurity = 'Public' | 'Private by Role';
+import { DashboardObjectItem, DashboardObjectItemObject } from "./dashboardObjectItem";
 
-type WebPageObject = {
-  name: string;
+type WebPageObject = Omit<DashboardObjectItemObject, 'type'> & {
   url: string;
   forceRefresh?: boolean;
-  hideHeader?: boolean;
-  hideContainer?: boolean;
-  view?: ViewSecurity;
-  roles?: string[];
 };
 
-export class WebPage {
-  name: string;
+export class WebPage extends DashboardObjectItem {
   url: string;
   forceRefresh: boolean;
-  hideHeader: boolean;
-  hideContainer: boolean;
-  view: ViewSecurity;
-  roles: string[];
 
   constructor({
     name,
@@ -28,12 +18,9 @@ export class WebPage {
     view = 'Public',
     roles = [],
   }: WebPageObject) {
-    this.name = name;
+    super({ name, type: 'Web Page', hideHeader, hideContainer, view, roles });
+
     this.url = url;
     this.forceRefresh = forceRefresh;
-    this.hideHeader = hideHeader;
-    this.hideContainer = hideContainer;
-    this.view = view;
-    this.roles = roles;
   }
 }

--- a/models/webPage.ts
+++ b/models/webPage.ts
@@ -1,4 +1,4 @@
-import { DashboardObjectItem, DashboardObjectItemObject } from "./dashboardObjectItem";
+import { DashboardObjectItem, DashboardObjectItemObject } from './dashboardObjectItem';
 
 type WebPageObject = Omit<DashboardObjectItemObject, 'type'> & {
   url: string;

--- a/models/webPage.ts
+++ b/models/webPage.ts
@@ -23,4 +23,16 @@ export class WebPage extends DashboardObjectItem {
     this.url = url;
     this.forceRefresh = forceRefresh;
   }
+
+  clone() {
+    return new WebPage({
+      name: this.name,
+      url: this.url,
+      forceRefresh: this.forceRefresh,
+      hideHeader: this.hideHeader,
+      hideContainer: this.hideContainer,
+      view: this.view,
+      roles: [...this.roles],
+    });
+  }
 }

--- a/models/webPage.ts
+++ b/models/webPage.ts
@@ -1,0 +1,39 @@
+type ViewSecurity = 'Public' | 'Private by Role';
+
+type WebPageObject = {
+  name: string;
+  url: string;
+  forceRefresh?: boolean;
+  hideHeader?: boolean;
+  hideContainer?: boolean;
+  view?: ViewSecurity;
+  roles?: string[];
+};
+
+export class WebPage {
+  name: string;
+  url: string;
+  forceRefresh: boolean;
+  hideHeader: boolean;
+  hideContainer: boolean;
+  view: ViewSecurity;
+  roles: string[];
+
+  constructor({
+    name,
+    url,
+    forceRefresh = false,
+    hideHeader = false,
+    hideContainer = false,
+    view = 'Public',
+    roles = [],
+  }: WebPageObject) {
+    this.name = name;
+    this.url = url;
+    this.forceRefresh = forceRefresh;
+    this.hideHeader = hideHeader;
+    this.hideContainer = hideContainer;
+    this.view = view;
+    this.roles = roles;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "format:test": "prettier . --check",
     "format:fix": "prettier . --write",
     "cleanup:outputs": "rimraf ./blob-report/ ./playwright-report/ ./test-results/ ./cleanup-results/ ./downloads/ ./data-import-files/ ./dynamic-documents/ ./apiSetupResults/",
-    "generate-example-env": "node ./scripts/generateExampleEnv.js"
+    "generate-example-env": "node ./scripts/generateExampleEnv.js",
+    "count-lines": "node ./scripts/countLines.mjs"
   },
   "keywords": [
     "onspring",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "format:fix": "prettier . --write",
     "cleanup:outputs": "rimraf ./blob-report/ ./playwright-report/ ./test-results/ ./cleanup-results/ ./downloads/ ./data-import-files/ ./dynamic-documents/ ./apiSetupResults/",
     "generate-example-env": "node ./scripts/generateExampleEnv.js",
-    "line-count": "node ./scripts/countLines.mjs"
+    "line-count": "node ./scripts/countLines.js"
   },
   "keywords": [
     "onspring",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "format:fix": "prettier . --write",
     "cleanup:outputs": "rimraf ./blob-report/ ./playwright-report/ ./test-results/ ./cleanup-results/ ./downloads/ ./data-import-files/ ./dynamic-documents/ ./apiSetupResults/",
     "generate-example-env": "node ./scripts/generateExampleEnv.js",
-    "count-lines": "node ./scripts/countLines.mjs"
+    "line-count": "node ./scripts/countLines.mjs"
   },
   "keywords": [
     "onspring",

--- a/pageObjectModels/content/addContentPage.ts
+++ b/pageObjectModels/content/addContentPage.ts
@@ -13,4 +13,17 @@ export class AddContentPage extends EditableContentPage {
   async goto(appId: number) {
     await this.page.goto(`/Content/${appId}/Add`);
   }
+
+  getAppIdFromUrl() {
+    const url = this.page.url();
+    const match = url.match(this.pathRegex);
+
+    if (match === null) {
+      throw new Error('The current page is not an add content page.');
+    }
+
+    const urlParts = url.split('/');
+    const appId = urlParts[urlParts.length - 2];
+    return parseInt(appId);
+  }
 }

--- a/pageObjectModels/content/appContentPage.ts
+++ b/pageObjectModels/content/appContentPage.ts
@@ -25,7 +25,7 @@ export class AppContentPage extends BasePage {
   getAppIdFromUrl() {
     const url = this.page.url();
     const match = url.match(this.pathRegex);
-   
+
     if (match === null) {
       throw new Error('The current page is not an app content page.');
     }

--- a/pageObjectModels/content/appContentPage.ts
+++ b/pageObjectModels/content/appContentPage.ts
@@ -1,19 +1,42 @@
-import { Page } from '@playwright/test';
+import { Locator, Page } from '@playwright/test';
 import { QuickContentAddForm } from '../../componentObjectModels/forms/quickContentAddForm';
 import { AppContentToolbar } from '../../componentObjectModels/toolbars/appContentToolbar';
 import { BasePage } from '../basePage';
 
 export class AppContentPage extends BasePage {
+  private readonly searchResults: Locator;
+  readonly pathRegex: RegExp;
   readonly toolbar: AppContentToolbar;
   readonly quickContentAddForm: QuickContentAddForm;
 
   constructor(page: Page) {
     super(page);
+
+    this.pathRegex = /\/Content\/\d+\/App/;
     this.toolbar = new AppContentToolbar(page);
     this.quickContentAddForm = new QuickContentAddForm(page.locator('form', { hasText: 'Quick Content Add' }));
+    this.searchResults = this.page.locator('#app-search-results');
   }
 
   async goto(appId: number) {
     await this.page.goto(`/Content/${appId}/App`);
+  }
+
+  getAppIdFromUrl() {
+    const url = this.page.url();
+    const match = url.match(this.pathRegex);
+   
+    if (match === null) {
+      throw new Error('The current page is not an app content page.');
+    }
+
+    const urlParts = url.split('/');
+    const appId = urlParts[urlParts.length - 2];
+    return parseInt(appId);
+  }
+
+  getSearchResultByRecordId(recordId: number) {
+    const appId = this.getAppIdFromUrl();
+    return this.searchResults.locator(`a[href="/Content/${appId}/${recordId}"]`);
   }
 }

--- a/pageObjectModels/dashboards/dashboardPage.ts
+++ b/pageObjectModels/dashboards/dashboardPage.ts
@@ -10,6 +10,7 @@ import { BasePage } from '../basePage';
 export class DashboardPage extends BasePage {
   private actionMenuButton: Locator;
   private actionMenu: DashboardActionMenu;
+  private dashboardContents: Locator;
   readonly path: string;
   readonly dashboardDesigner: DashboardDesignerModal;
   readonly printDashboardModal: PrintDashboardModal;
@@ -31,6 +32,7 @@ export class DashboardPage extends BasePage {
     this.dashboardLinkModal = new DashboardLinkModal(this.page);
     this.dashboardBreadcrumbTitle = this.page.locator('#dashboard-breadcrumbs .bcrumb-end');
     this.dashboardTitle = this.page.locator('#dashboard-title-container');
+    this.dashboardContents = this.page.locator('#dashboard-contents');
   }
 
   async goto(dashboardId?: number) {
@@ -76,5 +78,9 @@ export class DashboardPage extends BasePage {
     }
 
     return link[0];
+  }
+
+  getDashboardItem(name: string) {
+    return this.dashboardContents.locator('.dashboard-item', { has: this.page.locator(`.title:has-text("${name}")`) });
   }
 }

--- a/pageObjectModels/dashboards/dashboardsAdminPage.ts
+++ b/pageObjectModels/dashboards/dashboardsAdminPage.ts
@@ -122,4 +122,10 @@ export class DashboardsAdminPage extends BaseAdminPage {
       isVisible = await deleteConnectorRow.isVisible();
     }
   }
+
+  async deleteAllTestDashboardObjects() {
+    await this.goto();
+    await this.openDashboardDesigner('Welcome to Onspring');
+    await this.dashboardDesigner.deleteAllDashboardObjects();
+  }
 }

--- a/scripts/countLines.js
+++ b/scripts/countLines.js
@@ -1,0 +1,69 @@
+import fs from 'fs/promises';
+import path from 'path';
+import ignore from 'ignore';
+
+try{
+  await countLines();
+} catch (error) {
+  console.error('Error:', error);
+  process.exit(1);
+}
+
+async function countLines() {
+  const repoRoot = process.cwd();
+  let totalLines = 0;
+  let totalFiles = 0;
+
+  const gitignorePatterns = await getGitignorePatterns(repoRoot);
+  const ig = ignore().add(gitignorePatterns);
+
+  async function walkDir(currentPath) {
+    const entries = await fs.readdir(currentPath, { withFileTypes: true });
+
+    for (const entry of entries) {
+      const fullPath = path.join(currentPath, entry.name);
+      const relativePath = path.relative(repoRoot, fullPath);
+
+      if (ig.ignores(relativePath)) {
+        continue;
+      }
+
+      if (entry.isDirectory()) {
+        await walkDir(fullPath);
+      } else if (entry.isFile() && (entry.name.endsWith('.ts') || entry.name.endsWith('.tsx'))) {
+        totalFiles++;
+        const lines = await countLinesInFile(fullPath);
+        totalLines += lines;
+      }
+    }
+  }
+
+  console.log('Counting lines in TypeScript files...');
+  
+  await walkDir(repoRoot);
+
+  console.log(`--- Summary ---`);
+  console.log(`Total TypeScript files found: ${totalFiles}`);
+  console.log(`Total lines of TypeScript code: ${totalLines}`);
+}
+
+async function countLinesInFile(filePath) {
+  try {
+    const content = await fs.readFile(filePath, 'utf8');
+    return content.split('\n').length;
+  } catch (error) {
+    console.warn(`Could not read file: ${filePath} - ${error.message}`);
+    return 0;
+  }
+}
+
+
+async function getGitignorePatterns(repoRoot) {
+  const gitignorePath = path.join(repoRoot, '.gitignore');
+  try {
+    const content = await fs.readFile(gitignorePath, 'utf8');
+    return content.split('\n').filter(line => line.trim() !== '' && !line.startsWith('#'));
+  } catch (error) {
+    return [];
+  }
+}

--- a/scripts/countLines.js
+++ b/scripts/countLines.js
@@ -2,7 +2,7 @@ import fs from 'fs/promises';
 import path from 'path';
 import ignore from 'ignore';
 
-try{
+try {
   await countLines();
 } catch (error) {
   console.error('Error:', error);
@@ -39,7 +39,7 @@ async function countLines() {
   }
 
   console.log('Counting lines in TypeScript files...');
-  
+
   await walkDir(repoRoot);
 
   console.log(`--- Summary ---`);
@@ -56,7 +56,6 @@ async function countLinesInFile(filePath) {
     return 0;
   }
 }
-
 
 async function getGitignorePatterns(repoRoot) {
   const gitignorePath = path.join(repoRoot, '.gitignore');

--- a/tests/dashboard/dashboard.spec.ts
+++ b/tests/dashboard/dashboard.spec.ts
@@ -307,7 +307,7 @@ test.describe('dashboard', () => {
       containers: [container.name],
       items: [
         {
-          object: report,
+          item: report,
           row: 0,
           column: 0,
         },
@@ -366,7 +366,7 @@ test.describe('dashboard', () => {
       containers: [container.name],
       items: [
         {
-          object: report,
+          item: report,
           row: 0,
           column: 0,
         },
@@ -440,7 +440,7 @@ test.describe('dashboard', () => {
       containers: [container.name],
       items: [
         {
-          object: report,
+          item: report,
           row: 0,
           column: 0,
         },
@@ -534,7 +534,7 @@ test.describe('dashboard', () => {
       containers: [container.name],
       items: [
         {
-          object: report,
+          item: report,
           row: 0,
           column: 0,
         },
@@ -618,7 +618,7 @@ test.describe('dashboard', () => {
       containers: [container.name],
       items: [
         {
-          object: report,
+          item: report,
           row: 0,
           column: 0,
         },
@@ -670,7 +670,7 @@ test.describe('dashboard', () => {
         containers: [container.name],
         items: [
           {
-            object: report,
+            item: report,
             row: 0,
             column: 0,
           },
@@ -681,7 +681,7 @@ test.describe('dashboard', () => {
         containers: [container.name],
         items: [
           {
-            object: report,
+            item: report,
             row: 0,
             column: 0,
           },
@@ -733,7 +733,7 @@ test.describe('dashboard', () => {
       containers: [container.name],
       items: [
         {
-          object: report,
+          item: report,
           row: 0,
           column: 0,
         },
@@ -776,7 +776,7 @@ test.describe('dashboard', () => {
       containers: [container.name],
       items: [
         {
-          object: report,
+          item: report,
           row: 0,
           column: 0,
         },
@@ -816,7 +816,7 @@ test.describe('dashboard', () => {
       containers: [container.name],
       items: [
         {
-          object: report,
+          item: report,
           row: 0,
           column: 0,
         },
@@ -879,7 +879,7 @@ test.describe('dashboard', () => {
       containers: [container.name],
       items: [
         {
-          object: report,
+          item: report,
           row: 0,
           column: 0,
         },
@@ -937,7 +937,7 @@ test.describe('dashboard', () => {
       containers: [container.name],
       items: [
         {
-          object: report,
+          item: report,
           row: 0,
           column: 0,
         },
@@ -989,7 +989,7 @@ test.describe('dashboard', () => {
       containers: [container.name],
       items: [
         {
-          object: report,
+          item: report,
           row: 0,
           column: 0,
         },

--- a/tests/dashboardObjects/dashboardObjects.spec.ts
+++ b/tests/dashboardObjects/dashboardObjects.spec.ts
@@ -822,10 +822,49 @@ test.describe('dashboard objects', () => {
     });
   });
 
-  test('Verify a Web Page object displays and functions as expected', async () => {
+  test('Verify a Web Page object displays and functions as expected', async ({
+    dashboardsAdminPage,
+    dashboard,
+    dashboardPage,
+  }) => {
     test.info().annotations.push({
       type: AnnotationType.TestId,
       description: 'Test-773',
+    });
+
+    const webPageObject = new WebPage({
+      name: FakeDataFactory.createFakeObjectName(),
+      url: 'https://stevanfreeborn.com',
+    });
+
+    await test.step('Navigate to the dashboards admin page', async () => {
+      await dashboardsAdminPage.goto();
+    });
+
+    await test.step('Open the dashboard designer', async () => {
+      await dashboardsAdminPage.openDashboardDesigner(dashboard.name);
+    });
+
+    await test.step('Add a web page object', async () => {
+      await dashboardsAdminPage.dashboardDesigner.addDashboardObject(webPageObject);
+
+      dashboard.items.push({ row: 0, column: 0, item: webPageObject });
+
+      await dashboardsAdminPage.dashboardDesigner.updateDashboard(dashboard);
+      await dashboardsAdminPage.dashboardDesigner.saveAndClose();
+    });
+
+    await test.step('Navigate to the dashboard page', async () => {
+      await dashboardPage.goto(dashboard.id);
+    });
+
+    await test.step('Verify the web page object displays as expected', async () => {
+      const item = dashboardPage.getDashboardItem(webPageObject.name);
+      const iframe = item.locator('iframe');
+
+      await expect(item).toBeVisible();
+      await expect(iframe).toBeVisible();
+      await expect(iframe).toHaveAttribute('src', webPageObject.url);
     });
 
     expect(true).toBeTruthy();

--- a/tests/dashboardObjects/dashboardObjects.spec.ts
+++ b/tests/dashboardObjects/dashboardObjects.spec.ts
@@ -256,7 +256,7 @@ test.describe('dashboard objects', () => {
       await expect(item).toBeVisible();
     });
 
-    const updatedAppSearchObject = structuredClone(appSearchObject);
+    const updatedAppSearchObject = appSearchObject.clone();
     updatedAppSearchObject.name = FakeDataFactory.createFakeObjectName();
 
     dashboardObjectsToDelete.push(updatedAppSearchObject);
@@ -312,7 +312,7 @@ test.describe('dashboard objects', () => {
       await expect(item).toBeVisible();
     });
 
-    const updatedCreateContentLinksObject = structuredClone(createContentLinksObject);
+    const updatedCreateContentLinksObject = createContentLinksObject.clone();
     updatedCreateContentLinksObject.name = FakeDataFactory.createFakeObjectName();
 
     dashboardObjectsToDelete.push(updatedCreateContentLinksObject);
@@ -370,7 +370,7 @@ test.describe('dashboard objects', () => {
       await expect(item).toBeVisible();
     });
 
-    const updatedFormattedTextBlock = structuredClone(formattedTextBlock);
+    const updatedFormattedTextBlock = formattedTextBlock.clone();
     updatedFormattedTextBlock.name = FakeDataFactory.createFakeObjectName();
 
     dashboardObjectsToDelete.push(updatedFormattedTextBlock);
@@ -426,7 +426,7 @@ test.describe('dashboard objects', () => {
       await expect(item).toBeVisible();
     });
 
-    const updatedWebPageObject = structuredClone(webPageObject);
+    const updatedWebPageObject = webPageObject.clone();
     updatedWebPageObject.name = FakeDataFactory.createFakeObjectName();
 
     dashboardObjectsToDelete.push(updatedWebPageObject);
@@ -700,13 +700,10 @@ test.describe('dashboard objects', () => {
       await dashboardsAdminPage.dashboardDesigner.saveAndClose();
     });
 
-    await test.step('Navigate to the dashboard page', async () => {
+    await test.step('Navigate to dashboard, search for the created record, and verify it displays in results', async () => {
       await dashboardPage.goto(dashboard.id);
-    });
 
-    const appContentPage = new AppContentPage(sysAdminPage);
-
-    await test.step('Search for the created record', async () => {
+      const appContentPage = new AppContentPage(sysAdminPage);
       const item = dashboardPage.getDashboardItem(appSearchObject.name);
       const searchBox = item.getByPlaceholder(`Search ${sourceApp.name}`);
       const searchButton = item.getByRole('button');
@@ -714,12 +711,8 @@ test.describe('dashboard objects', () => {
       await searchBox.fill(createdRecordId.toString());
       await searchButton.click();
       await dashboardPage.page.waitForURL(appContentPage.pathRegex);
-    });
-
-    await test.step('Verify the created record is displayed in search results', async () => {
-      const searchResult = appContentPage.getSearchResultByRecordId(createdRecordId);
-
-      await expect(searchResult).toBeVisible();
+      
+      await expect(appContentPage.page).toHaveURL(appContentPage.pathRegex);
     });
   });
 

--- a/tests/dashboardObjects/dashboardObjects.spec.ts
+++ b/tests/dashboardObjects/dashboardObjects.spec.ts
@@ -739,7 +739,7 @@ test.describe('dashboard objects', () => {
       name: FakeDataFactory.createFakeObjectName(),
       links: [{ app: sourceApp.name, imageSource: { src: 'App' }, linkText: 'Test Link' }],
     });
-    
+
     await test.step('Navigate to the dashboards admin page', async () => {
       await dashboardsAdminPage.goto();
     });

--- a/tests/dashboardObjects/dashboardObjects.spec.ts
+++ b/tests/dashboardObjects/dashboardObjects.spec.ts
@@ -274,31 +274,178 @@ test.describe('dashboard objects', () => {
     });
   });
 
-  test('Modify a Create Content Links object', async () => {
+  test('Modify a Create Content Links object', async ({
+    sourceApp,
+    dashboardsAdminPage,
+    dashboard,
+    dashboardPage,
+  }) => {
     test.info().annotations.push({
       type: AnnotationType.TestId,
       description: 'Test-763',
     });
+    
+    const createContentLinksObject = new CreateContentLinks({
+      name: FakeDataFactory.createFakeObjectName(),
+      links: [{ app: sourceApp.name, imageSource: { src: 'App' }, linkText: 'Test Link' }],
+    });
 
-    expect(true).toBeTruthy();
+    await test.step('Navigate to the dashboards admin page', async () => {
+      await dashboardsAdminPage.goto();
+    });
+
+    await test.step('Open the dashboard designer', async () => {
+      await dashboardsAdminPage.openDashboardDesigner(dashboard.name);
+    });
+
+    await test.step('Add a create content links object', async () => {
+      await dashboardsAdminPage.dashboardDesigner.addDashboardObject(createContentLinksObject);
+
+      dashboard.items.push({ row: 0, column: 1, item: createContentLinksObject });
+
+      await dashboardsAdminPage.dashboardDesigner.updateDashboard(dashboard);
+      await dashboardsAdminPage.dashboardDesigner.saveAndClose();
+    });
+
+    await test.step('Navigate to the dashboard page', async () => {
+      await dashboardPage.goto(dashboard.id);
+    });
+
+    await test.step('Verify the create content links object displays', async () => {
+      const item = dashboardPage.getDashboardItem(createContentLinksObject.name);
+      await expect(item).toBeVisible();
+    });
+
+    const updatedCreateContentLinksObject = structuredClone(createContentLinksObject);
+    updatedCreateContentLinksObject.name = FakeDataFactory.createFakeObjectName();
+
+    await test.step('Modify the create content links object', async () => {
+      await dashboardPage.openDashboardDesigner();
+      await dashboardPage.dashboardDesigner.updateDashboardObject(createContentLinksObject, updatedCreateContentLinksObject);
+      await dashboardPage.dashboardDesigner.close();
+    });
+
+    await test.step('Verify the create content links object is modified', async () => {
+      await dashboardPage.page.reload();
+
+      const item = dashboardPage.getDashboardItem(updatedCreateContentLinksObject.name);
+      await expect(item).toBeVisible();
+    });
   });
 
-  test('Modify a Formatted Text Block object', async () => {
+  test('Modify a Formatted Text Block object', async ({
+    dashboardsAdminPage,
+    dashboard,
+    dashboardPage,
+  }) => {
     test.info().annotations.push({
       type: AnnotationType.TestId,
       description: 'Test-764',
     });
 
-    expect(true).toBeTruthy();
+    const formattedTextBlock = new FormattedTextBlock({
+      name: FakeDataFactory.createFakeObjectName(),
+    });
+
+    await test.step('Navigate to the dashboards admin page', async () => {
+      await dashboardsAdminPage.goto();
+    });
+
+    await test.step('Open the dashboard designer', async () => {
+      await dashboardsAdminPage.openDashboardDesigner(dashboard.name);
+    });
+
+    await test.step('Add a formatted text block object', async () => {
+      await dashboardsAdminPage.dashboardDesigner.addDashboardObject(formattedTextBlock);
+
+      dashboard.items.push({ row: 0, column: 0, item: formattedTextBlock });
+
+      await dashboardsAdminPage.dashboardDesigner.updateDashboard(dashboard);
+      await dashboardsAdminPage.dashboardDesigner.saveAndClose();
+    });
+
+    await test.step('Navigate to the dashboard page', async () => {
+      await dashboardPage.goto(dashboard.id);
+    });
+
+    await test.step('Verify the formatted text block object displays', async () => {
+      const item = dashboardPage.getDashboardItem(formattedTextBlock.name);
+      await expect(item).toBeVisible();
+    });
+
+    const updatedFormattedTextBlock = structuredClone(formattedTextBlock);
+    updatedFormattedTextBlock.name = FakeDataFactory.createFakeObjectName();
+
+    await test.step('Modify the formatted text block object', async () => {
+      await dashboardPage.openDashboardDesigner();
+      await dashboardPage.dashboardDesigner.updateDashboardObject(formattedTextBlock, updatedFormattedTextBlock);
+      await dashboardPage.dashboardDesigner.close();
+    });
+
+    await test.step('Verify the formatted text block object is modified', async () => {
+      await dashboardPage.page.reload();
+
+      const item = dashboardPage.getDashboardItem(updatedFormattedTextBlock.name);
+      await expect(item).toBeVisible();
+    });
   });
 
-  test('Modify a Web Page object', async () => {
+  test('Modify a Web Page object', async ({
+    dashboardsAdminPage,
+    dashboard,
+    dashboardPage,
+  }) => {
     test.info().annotations.push({
       type: AnnotationType.TestId,
       description: 'Test-765',
     });
 
-    expect(true).toBeTruthy();
+    const webPageObject = new WebPage({
+      name: FakeDataFactory.createFakeObjectName(),
+      url: 'https://stevanfreeborn.com',
+    });
+
+    await test.step('Navigate to the dashboards admin page', async () => {
+      await dashboardsAdminPage.goto();
+    });
+
+    await test.step('Open the dashboard designer', async () => {
+      await dashboardsAdminPage.openDashboardDesigner(dashboard.name);
+    });
+
+    await test.step('Add a web page object', async () => {
+      await dashboardsAdminPage.dashboardDesigner.addDashboardObject(webPageObject);
+
+      dashboard.items.push({ row: 0, column: 0, item: webPageObject });
+
+      await dashboardsAdminPage.dashboardDesigner.updateDashboard(dashboard);
+      await dashboardsAdminPage.dashboardDesigner.saveAndClose();
+    });
+
+    await test.step('Navigate to the dashboard page', async () => {
+      await dashboardPage.goto(dashboard.id);
+    });
+
+    await test.step('Verify the web page object displays', async () => {
+      const item = dashboardPage.getDashboardItem(webPageObject.name);
+      await expect(item).toBeVisible();
+    });
+
+    const updatedWebPageObject = structuredClone(webPageObject);
+    updatedWebPageObject.name = FakeDataFactory.createFakeObjectName();
+
+    await test.step('Modify the web page object', async () => {
+      await dashboardPage.openDashboardDesigner();
+      await dashboardPage.dashboardDesigner.updateDashboardObject(webPageObject, updatedWebPageObject);
+      await dashboardPage.dashboardDesigner.close();
+    });
+
+    await test.step('Verify the web page object is modified', async () => {
+      await dashboardPage.page.reload();
+
+      const item = dashboardPage.getDashboardItem(updatedWebPageObject.name);
+      await expect(item).toBeVisible();
+    });
   });
 
   test('Delete an App Search object', async ({ sourceApp, dashboardsAdminPage, dashboard, dashboardPage }) => {

--- a/tests/dashboardObjects/dashboardObjects.spec.ts
+++ b/tests/dashboardObjects/dashboardObjects.spec.ts
@@ -9,6 +9,7 @@ import { Container } from '../../models/container';
 import { CreateContentLinks } from '../../models/createContentLinks';
 import { Dashboard } from '../../models/dashboard';
 import { DashboardFormattedTextBlock as FormattedTextBlock } from '../../models/dashboardFormattedTextBlock';
+import { WebPage } from '../../models/webPage';
 import { DashboardPage } from '../../pageObjectModels/dashboards/dashboardPage';
 import { DashboardsAdminPage } from '../../pageObjectModels/dashboards/dashboardsAdminPage';
 import { AnnotationType } from '../annotations';
@@ -154,13 +155,46 @@ test.describe('dashboard objects', () => {
     });
   });
 
-  test('Add a Web Page object', async () => {
+  test('Add a Web Page object', async ({
+    dashboardsAdminPage,
+    dashboard,
+    dashboardPage,
+  }) => {
     test.info().annotations.push({
       type: AnnotationType.TestId,
       description: 'Test-761',
     });
 
-    expect(true).toBeTruthy();
+    const webPageObject = new WebPage({
+      name: FakeDataFactory.createFakeObjectName(),
+      url: 'https://stevanfreeborn.com',
+    });
+
+    await test.step('Navigate to the dashboards admin page', async () => {
+      await dashboardsAdminPage.goto();
+    });
+
+    await test.step('Open the dashboard designer', async () => {
+      await dashboardsAdminPage.openDashboardDesigner(dashboard.name);
+    });
+
+    await test.step('Add a web page object', async () => {
+      await dashboardsAdminPage.dashboardDesigner.addWebPageObject(webPageObject);
+
+      dashboard.items.push({ row: 0, column: 0, object: webPageObject });
+
+      await dashboardsAdminPage.dashboardDesigner.updateDashboard(dashboard);
+      await dashboardsAdminPage.dashboardDesigner.saveAndClose();
+    });
+
+    await test.step('Navigate to the dashboard page', async () => {
+      await dashboardPage.goto(dashboard.id);
+    });
+
+    await test.step('Verify the web page object displays', async () => {
+      const item = dashboardPage.getDashboardItem(webPageObject.name);
+      await expect(item).toBeVisible();
+    });
   });
 
   test('Modify an App Search object', async () => {

--- a/tests/dashboardObjects/dashboardObjects.spec.ts
+++ b/tests/dashboardObjects/dashboardObjects.spec.ts
@@ -260,6 +260,8 @@ test.describe('dashboard objects', () => {
     const updatedAppSearchObject = structuredClone(appSearchObject);
     updatedAppSearchObject.name = FakeDataFactory.createFakeObjectName();
 
+    dashboardObjectsToDelete.push(updatedAppSearchObject);
+
     await test.step('Modify the app search object', async () => {
       await dashboardPage.openDashboardDesigner();
       await dashboardPage.dashboardDesigner.updateDashboardObject(appSearchObject, updatedAppSearchObject);
@@ -318,6 +320,8 @@ test.describe('dashboard objects', () => {
 
     const updatedCreateContentLinksObject = structuredClone(createContentLinksObject);
     updatedCreateContentLinksObject.name = FakeDataFactory.createFakeObjectName();
+    
+    dashboardObjectsToDelete.push(updatedCreateContentLinksObject);
 
     await test.step('Modify the create content links object', async () => {
       await dashboardPage.openDashboardDesigner();
@@ -376,6 +380,8 @@ test.describe('dashboard objects', () => {
     const updatedFormattedTextBlock = structuredClone(formattedTextBlock);
     updatedFormattedTextBlock.name = FakeDataFactory.createFakeObjectName();
 
+    dashboardObjectsToDelete.push(updatedFormattedTextBlock);
+
     await test.step('Modify the formatted text block object', async () => {
       await dashboardPage.openDashboardDesigner();
       await dashboardPage.dashboardDesigner.updateDashboardObject(formattedTextBlock, updatedFormattedTextBlock);
@@ -433,6 +439,8 @@ test.describe('dashboard objects', () => {
 
     const updatedWebPageObject = structuredClone(webPageObject);
     updatedWebPageObject.name = FakeDataFactory.createFakeObjectName();
+
+    dashboardObjectsToDelete.push(updatedWebPageObject);
 
     await test.step('Modify the web page object', async () => {
       await dashboardPage.openDashboardDesigner();

--- a/tests/dashboardObjects/dashboardObjects.spec.ts
+++ b/tests/dashboardObjects/dashboardObjects.spec.ts
@@ -8,6 +8,7 @@ import { AppSearch } from '../../models/appSearch';
 import { Container } from '../../models/container';
 import { CreateContentLinks } from '../../models/createContentLinks';
 import { Dashboard } from '../../models/dashboard';
+import { DashboardFormattedTextBlock as FormattedTextBlock } from '../../models/dashboardFormattedTextBlock';
 import { DashboardPage } from '../../pageObjectModels/dashboards/dashboardPage';
 import { DashboardsAdminPage } from '../../pageObjectModels/dashboards/dashboardsAdminPage';
 import { AnnotationType } from '../annotations';
@@ -112,11 +113,40 @@ test.describe('dashboard objects', () => {
     });
   });
 
-  test('Add a Formatted Text Block object', async () => {
+  test('Add a Formatted Text Block object', async ({
+    dashboardsAdminPage,
+    dashboard,
+    dashboardPage,
+  }) => {
     test.info().annotations.push({
       type: AnnotationType.TestId,
       description: 'Test-760',
     });
+
+    const formattedTextBlock = new FormattedTextBlock({
+      name: FakeDataFactory.createFakeObjectName(),
+    })
+
+    await test.step('Navigate to the dashboards admin page', async () => {
+      await dashboardsAdminPage.goto();
+    });
+
+    await test.step('Open the dashboard designer', async () => {
+      await dashboardsAdminPage.openDashboardDesigner(dashboard.name);
+    });
+
+    await test.step('Add a formatted text block object', async () => {
+      await dashboardsAdminPage.dashboardDesigner.addFormattedTextBlockObject(formattedTextBlock);
+
+      dashboard.items.push({ row: 0, column: 0, object: formattedTextBlock });
+
+      await dashboardsAdminPage.dashboardDesigner.updateDashboard(dashboard);
+      await dashboardsAdminPage.dashboardDesigner.saveAndClose();
+    });
+
+    await test.step('Navigate to the dashboard page', async () => {});
+
+    await test.step('Verify the formatted text block object displays', async () => {});
 
     expect(true).toBeTruthy();
   });

--- a/tests/dashboardObjects/dashboardObjects.spec.ts
+++ b/tests/dashboardObjects/dashboardObjects.spec.ts
@@ -1,0 +1,149 @@
+import { test, expect } from '../../fixtures';
+import { AnnotationType } from '../annotations';
+
+test.describe('dashboard objects', () => {
+  test('Add an App Search object', async () => {
+    test.info().annotations.push({
+      type: AnnotationType.TestId,
+      description: 'Test-758',
+    });
+
+    expect(true).toBeTruthy();
+  });
+
+  test('Add a Create Content Links object', async () => {
+    test.info().annotations.push({
+      type: AnnotationType.TestId,
+      description: 'Test-759',
+    });
+
+    expect(true).toBeTruthy();
+  });
+
+  test('Add a Formatted Text Block object', async () => {
+    test.info().annotations.push({
+      type: AnnotationType.TestId,
+      description: 'Test-760',
+    });
+
+    expect(true).toBeTruthy();
+  });
+
+
+  test('Add a Web Page object', async () => {
+    test.info().annotations.push({
+      type: AnnotationType.TestId,
+      description: 'Test-761',
+    });
+
+    expect(true).toBeTruthy();
+  });
+
+  test('Modify an App Search object', async () => {
+    test.info().annotations.push({
+      type: AnnotationType.TestId,
+      description: 'Test-762',
+    });
+
+    expect(true).toBeTruthy();
+  });
+
+  test('Modify a Create Content Links object', async () => {
+    test.info().annotations.push({
+      type: AnnotationType.TestId,
+      description: 'Test-763',
+    });
+
+    expect(true).toBeTruthy();
+  });
+
+  test('Modify a Formatted Text Block object', async () => {
+    test.info().annotations.push({
+      type: AnnotationType.TestId,
+      description: 'Test-764',
+    });
+
+    expect(true).toBeTruthy();
+  });
+
+  test('Modify a Web Page object', async () => {
+    test.info().annotations.push({
+      type: AnnotationType.TestId,
+      description: 'Test-765',
+    });
+
+    expect(true).toBeTruthy();
+  });
+
+  test('Delete an App Search object', async () => {
+    test.info().annotations.push({
+      type: AnnotationType.TestId,
+      description: 'Test-766',
+    });
+
+    expect(true).toBeTruthy();
+  });
+
+  test('Delete a Create Content Links object', async () => {
+    test.info().annotations.push({
+      type: AnnotationType.TestId,
+      description: 'Test-767',
+    });
+
+    expect(true).toBeTruthy();
+  });
+
+  test('Delete a Formatted Text Block object', async () => {
+    test.info().annotations.push({
+      type: AnnotationType.TestId,
+      description: 'Test-768',
+    });
+
+    expect(true).toBeTruthy();
+  });
+
+  test('Delete a Web Page object', async () => {
+    test.info().annotations.push({
+      type: AnnotationType.TestId,
+      description: 'Test-769',
+    });
+
+    expect(true).toBeTruthy();
+  });
+
+  test('Verify an App Search object displays and functions as expected', async () => {
+    test.info().annotations.push({
+      type: AnnotationType.TestId,
+      description: 'Test-770',
+    });
+
+    expect(true).toBeTruthy();
+  });
+
+  test('Verify a Create Content Links object displays and functions as expected', async () => {
+    test.info().annotations.push({
+      type: AnnotationType.TestId,
+      description: 'Test-771',
+    });
+
+    expect(true).toBeTruthy();
+  });
+
+  test('Verify a Formatted Text Block object displays and functions as expected', async () => {
+    test.info().annotations.push({
+      type: AnnotationType.TestId,
+      description: 'Test-772',
+    });
+
+    expect(true).toBeTruthy();
+  });
+
+  test('Verify a Web Page object displays and functions as expected', async () => {
+    test.info().annotations.push({
+      type: AnnotationType.TestId,
+      description: 'Test-773',
+    });
+
+    expect(true).toBeTruthy();
+  });
+});

--- a/tests/dashboardObjects/dashboardObjects.spec.ts
+++ b/tests/dashboardObjects/dashboardObjects.spec.ts
@@ -6,6 +6,7 @@ import { createDashboardFixture } from '../../fixtures/dashboard.fixtures';
 import { App } from '../../models/app';
 import { AppSearch } from '../../models/appSearch';
 import { Container } from '../../models/container';
+import { CreateContentLinks } from '../../models/createContentLinks';
 import { Dashboard } from '../../models/dashboard';
 import { DashboardPage } from '../../pageObjectModels/dashboards/dashboardPage';
 import { DashboardsAdminPage } from '../../pageObjectModels/dashboards/dashboardsAdminPage';
@@ -81,6 +82,7 @@ test.describe('dashboard objects', () => {
 
     const createContentLinksObject = new CreateContentLinks({
       name: FakeDataFactory.createFakeObjectName(),
+      links: [{ app: sourceApp.name, imageSource: { src: 'App' }, linkText: 'Test Link' }],
     });
 
     await test.step('Navigate to the dashboards admin page', async () => {

--- a/tests/dashboardObjects/dashboardObjects.spec.ts
+++ b/tests/dashboardObjects/dashboardObjects.spec.ts
@@ -407,13 +407,59 @@ test.describe('dashboard objects', () => {
     });
   });
 
-  test('Delete a Web Page object', async () => {
+  test('Delete a Web Page object', async ({
+    dashboardsAdminPage,
+    dashboard,
+    dashboardPage,
+  }) => {
     test.info().annotations.push({
       type: AnnotationType.TestId,
       description: 'Test-769',
     });
 
-    expect(true).toBeTruthy();
+    const webPageObject = new WebPage({
+      name: FakeDataFactory.createFakeObjectName(),
+      url: 'https://stevanfreeborn.com',
+    });
+
+    await test.step('Navigate to the dashboards admin page', async () => {
+      await dashboardsAdminPage.goto();
+    });
+
+    await test.step('Open the dashboard designer', async () => {
+      await dashboardsAdminPage.openDashboardDesigner(dashboard.name);
+    });
+
+    await test.step('Add a web page object to the dashboard', async () => {
+      await dashboardsAdminPage.dashboardDesigner.addDashboardObject(webPageObject);
+
+      dashboard.items.push({ row: 0, column: 0, item: webPageObject });
+
+      await dashboardsAdminPage.dashboardDesigner.updateDashboard(dashboard);
+      await dashboardsAdminPage.dashboardDesigner.saveAndClose();
+    });
+
+    await test.step('Navigate to the dashboard page', async () => {
+      await dashboardPage.goto(dashboard.id);
+    });
+
+    await test.step('Verify the web page object displays', async () => {
+      const item = dashboardPage.getDashboardItem(webPageObject.name);
+      await expect(item).toBeVisible();
+    });
+
+    await test.step('Delete the web page object', async () => {
+      await dashboardPage.openDashboardDesigner();
+      await dashboardPage.dashboardDesigner.deleteDashboardObject(webPageObject);
+      await dashboardPage.dashboardDesigner.saveAndClose();
+    });
+
+    await test.step('Verify the web page object is deleted', async () => {
+      await dashboardPage.page.reload();
+
+      const item = dashboardPage.getDashboardItem(webPageObject.name);
+      await expect(item).toBeHidden();
+    });
   });
 
   test('Verify an App Search object displays and functions as expected', async () => {

--- a/tests/dashboardObjects/dashboardObjects.spec.ts
+++ b/tests/dashboardObjects/dashboardObjects.spec.ts
@@ -144,11 +144,14 @@ test.describe('dashboard objects', () => {
       await dashboardsAdminPage.dashboardDesigner.saveAndClose();
     });
 
-    await test.step('Navigate to the dashboard page', async () => {});
+    await test.step('Navigate to the dashboard page', async () => {
+      await dashboardPage.goto(dashboard.id);
+    });
 
-    await test.step('Verify the formatted text block object displays', async () => {});
-
-    expect(true).toBeTruthy();
+    await test.step('Verify the formatted text block object displays', async () => {
+      const item = dashboardPage.getDashboardItem(formattedTextBlock.name);
+      await expect(item).toBeVisible();
+    });
   });
 
   test('Add a Web Page object', async () => {

--- a/tests/dashboardObjects/dashboardObjects.spec.ts
+++ b/tests/dashboardObjects/dashboardObjects.spec.ts
@@ -711,7 +711,7 @@ test.describe('dashboard objects', () => {
       await searchBox.fill(createdRecordId.toString());
       await searchButton.click();
       await dashboardPage.page.waitForURL(appContentPage.pathRegex);
-      
+
       await expect(appContentPage.page).toHaveURL(appContentPage.pathRegex);
     });
   });

--- a/tests/dashboardObjects/dashboardObjects.spec.ts
+++ b/tests/dashboardObjects/dashboardObjects.spec.ts
@@ -723,13 +723,56 @@ test.describe('dashboard objects', () => {
     });
   });
 
-  test('Verify a Create Content Links object displays and functions as expected', async () => {
+  test('Verify a Create Content Links object displays and functions as expected', async ({
+    sysAdminPage,
+    sourceApp,
+    dashboardsAdminPage,
+    dashboard,
+    dashboardPage,
+  }) => {
     test.info().annotations.push({
       type: AnnotationType.TestId,
       description: 'Test-771',
     });
 
-    expect(true).toBeTruthy();
+    const createContentLinksObject = new CreateContentLinks({
+      name: FakeDataFactory.createFakeObjectName(),
+      links: [{ app: sourceApp.name, imageSource: { src: 'App' }, linkText: 'Test Link' }],
+    });
+    
+    await test.step('Navigate to the dashboards admin page', async () => {
+      await dashboardsAdminPage.goto();
+    });
+
+    await test.step('Open the dashboard designer', async () => {
+      await dashboardsAdminPage.openDashboardDesigner(dashboard.name);
+    });
+
+    await test.step('Add a create content links object', async () => {
+      await dashboardsAdminPage.dashboardDesigner.addDashboardObject(createContentLinksObject);
+
+      dashboard.items.push({ row: 0, column: 1, item: createContentLinksObject });
+
+      await dashboardsAdminPage.dashboardDesigner.updateDashboard(dashboard);
+      await dashboardsAdminPage.dashboardDesigner.saveAndClose();
+    });
+
+    await test.step('Navigate to the dashboard page', async () => {
+      await dashboardPage.goto(dashboard.id);
+    });
+
+    await test.step('Verify create content link takes you to add content page for the app', async () => {
+      const addContentPage = new AddContentPage(sysAdminPage);
+      const item = dashboardPage.getDashboardItem(createContentLinksObject.name);
+      const link = item.getByRole('link', { name: 'Test Link' });
+
+      await link.click();
+
+      await dashboardPage.page.waitForURL(addContentPage.pathRegex);
+
+      const appId = addContentPage.getAppIdFromUrl();
+      expect(appId).toBe(sourceApp.id);
+    });
   });
 
   test('Verify a Formatted Text Block object displays and functions as expected', async () => {

--- a/tests/dashboardObjects/dashboardObjects.spec.ts
+++ b/tests/dashboardObjects/dashboardObjects.spec.ts
@@ -775,13 +775,51 @@ test.describe('dashboard objects', () => {
     });
   });
 
-  test('Verify a Formatted Text Block object displays and functions as expected', async () => {
+  test('Verify a Formatted Text Block object displays and functions as expected', async ({
+    dashboardsAdminPage,
+    dashboard,
+    dashboardPage,
+  }) => {
     test.info().annotations.push({
       type: AnnotationType.TestId,
       description: 'Test-772',
     });
 
-    expect(true).toBeTruthy();
+    const formattedTextBlock = new FormattedTextBlock({
+      name: FakeDataFactory.createFakeObjectName(),
+      formattedText: 'Test formatted text block',
+    });
+
+    await test.step('Navigate to the dashboards admin page', async () => {
+      await dashboardsAdminPage.goto();
+    });
+
+    await test.step('Open the dashboard designer', async () => {
+      await dashboardsAdminPage.openDashboardDesigner(dashboard.name);
+    });
+
+    await test.step('Add a formatted text block object', async () => {
+      await dashboardsAdminPage.dashboardDesigner.addDashboardObject(formattedTextBlock);
+
+      dashboard.items.push({ row: 0, column: 0, item: formattedTextBlock });
+
+      await dashboardsAdminPage.dashboardDesigner.updateDashboard(dashboard);
+      await dashboardsAdminPage.dashboardDesigner.saveAndClose();
+    });
+
+    await test.step('Navigate to the dashboard page', async () => {
+      await dashboardPage.goto(dashboard.id);
+    });
+
+    await test.step('Verify the formatted text block object displays as expected', async () => {
+      const item = dashboardPage.getDashboardItem(formattedTextBlock.name);
+      const heading = item.getByRole('heading', { name: formattedTextBlock.name });
+      const textBlock = item.getByText(formattedTextBlock.formattedText);
+
+      await expect(item).toBeVisible();
+      await expect(heading).toBeVisible();
+      await expect(textBlock).toBeVisible();
+    });
   });
 
   test('Verify a Web Page object displays and functions as expected', async () => {

--- a/tests/dashboardObjects/dashboardObjects.spec.ts
+++ b/tests/dashboardObjects/dashboardObjects.spec.ts
@@ -7,12 +7,13 @@ import { App } from '../../models/app';
 import { AppSearch } from '../../models/appSearch';
 import { Container } from '../../models/container';
 import { CreateContentLinks } from '../../models/createContentLinks';
-import { Dashboard, DashboardItemObject } from '../../models/dashboard';
+import { Dashboard } from '../../models/dashboard';
 import { DashboardFormattedTextBlock as FormattedTextBlock } from '../../models/dashboardFormattedTextBlock';
 import { WebPage } from '../../models/webPage';
 import { DashboardPage } from '../../pageObjectModels/dashboards/dashboardPage';
 import { DashboardsAdminPage } from '../../pageObjectModels/dashboards/dashboardsAdminPage';
 import { AnnotationType } from '../annotations';
+import { DashboardObjectItem } from '../../models/dashboardObjectItem';
 
 type DashboardObjectTestFixtures = {
   dashboardsAdminPage: DashboardsAdminPage;
@@ -38,9 +39,13 @@ const test = base.extend<DashboardObjectTestFixtures>({
 });
 
 test.describe('dashboard objects', () => {
-  let dashboardObjectsToDelete: DashboardItemObject[] = [];
+  let dashboardObjectsToDelete: DashboardObjectItem[] = [];
 
   test.afterEach(async ({ dashboard, dashboardsAdminPage }) => {
+    if (dashboardObjectsToDelete.length === 0) {
+      return;
+    }
+
     await dashboardsAdminPage.goto();
     await dashboardsAdminPage.openDashboardDesigner(dashboard.name);
 
@@ -73,7 +78,7 @@ test.describe('dashboard objects', () => {
     });
 
     await test.step('Add an app search object', async () => {
-      await dashboardsAdminPage.dashboardDesigner.addAppSearchObject(appSearchObject);
+      await dashboardsAdminPage.dashboardDesigner.addDashboardObject(appSearchObject);
 
       dashboard.items.push({ row: 0, column: 0, item: appSearchObject });
 
@@ -113,7 +118,7 @@ test.describe('dashboard objects', () => {
     });
 
     await test.step('Add a create content links object', async () => {
-      await dashboardsAdminPage.dashboardDesigner.addCreateContentLinksObject(createContentLinksObject);
+      await dashboardsAdminPage.dashboardDesigner.addDashboardObject(createContentLinksObject);
 
       dashboard.items.push({ row: 0, column: 1, item: createContentLinksObject });
 
@@ -131,11 +136,7 @@ test.describe('dashboard objects', () => {
     });
   });
 
-  test('Add a Formatted Text Block object', async ({
-    dashboardsAdminPage,
-    dashboard,
-    dashboardPage,
-  }) => {
+  test('Add a Formatted Text Block object', async ({ dashboardsAdminPage, dashboard, dashboardPage }) => {
     test.info().annotations.push({
       type: AnnotationType.TestId,
       description: 'Test-760',
@@ -143,7 +144,7 @@ test.describe('dashboard objects', () => {
 
     const formattedTextBlock = new FormattedTextBlock({
       name: FakeDataFactory.createFakeObjectName(),
-    })
+    });
 
     dashboardObjectsToDelete.push(formattedTextBlock);
 
@@ -156,7 +157,7 @@ test.describe('dashboard objects', () => {
     });
 
     await test.step('Add a formatted text block object', async () => {
-      await dashboardsAdminPage.dashboardDesigner.addFormattedTextBlockObject(formattedTextBlock);
+      await dashboardsAdminPage.dashboardDesigner.addDashboardObject(formattedTextBlock);
 
       dashboard.items.push({ row: 0, column: 0, item: formattedTextBlock });
 
@@ -174,11 +175,7 @@ test.describe('dashboard objects', () => {
     });
   });
 
-  test('Add a Web Page object', async ({
-    dashboardsAdminPage,
-    dashboard,
-    dashboardPage,
-  }) => {
+  test('Add a Web Page object', async ({ dashboardsAdminPage, dashboard, dashboardPage }) => {
     test.info().annotations.push({
       type: AnnotationType.TestId,
       description: 'Test-761',
@@ -200,7 +197,7 @@ test.describe('dashboard objects', () => {
     });
 
     await test.step('Add a web page object', async () => {
-      await dashboardsAdminPage.dashboardDesigner.addWebPageObject(webPageObject);
+      await dashboardsAdminPage.dashboardDesigner.addDashboardObject(webPageObject);
 
       dashboard.items.push({ row: 0, column: 0, item: webPageObject });
 
@@ -254,12 +251,7 @@ test.describe('dashboard objects', () => {
     expect(true).toBeTruthy();
   });
 
-  test('Delete an App Search object', async ({
-    sourceApp,
-    dashboardsAdminPage,
-    dashboard,
-    dashboardPage,
-  }) => {
+  test('Delete an App Search object', async ({ sourceApp, dashboardsAdminPage, dashboard, dashboardPage }) => {
     test.info().annotations.push({
       type: AnnotationType.TestId,
       description: 'Test-766',
@@ -267,9 +259,7 @@ test.describe('dashboard objects', () => {
 
     const appSearchObject = new AppSearch({
       name: FakeDataFactory.createFakeObjectName(),
-      apps: [
-        sourceApp.name,
-      ],
+      apps: [sourceApp.name],
     });
 
     await test.step('Navigate to the dashboards admin page', async () => {
@@ -281,7 +271,7 @@ test.describe('dashboard objects', () => {
     });
 
     await test.step('Add an app search object to the dashboard', async () => {
-      await dashboardsAdminPage.dashboardDesigner.addAppSearchObject(appSearchObject);
+      await dashboardsAdminPage.dashboardDesigner.addDashboardObject(appSearchObject);
 
       dashboard.items.push({ row: 0, column: 0, item: appSearchObject });
 
@@ -312,11 +302,7 @@ test.describe('dashboard objects', () => {
     });
   });
 
-  test('Delete a Create Content Links object', async ({
-    dashboardsAdminPage,
-    dashboard,
-    dashboardPage,
-  }) => {
+  test('Delete a Create Content Links object', async ({ sourceApp, dashboardsAdminPage, dashboard, dashboardPage }) => {
     test.info().annotations.push({
       type: AnnotationType.TestId,
       description: 'Test-767',
@@ -324,7 +310,7 @@ test.describe('dashboard objects', () => {
 
     const createContentLinksObject = new CreateContentLinks({
       name: FakeDataFactory.createFakeObjectName(),
-      links: [{ app: 'App', imageSource: { src: 'App' }, linkText: 'Test Link' }],
+      links: [{ app: sourceApp.name, imageSource: { src: 'App' }, linkText: 'Test Link' }],
     });
 
     await test.step('Navigate to the dashboards admin page', async () => {
@@ -336,7 +322,7 @@ test.describe('dashboard objects', () => {
     });
 
     await test.step('Add a create content links object to the dashboard', async () => {
-      await dashboardsAdminPage.dashboardDesigner.addCreateContentLinksObject(createContentLinksObject);
+      await dashboardsAdminPage.dashboardDesigner.addDashboardObject(createContentLinksObject);
 
       dashboard.items.push({ row: 0, column: 1, item: createContentLinksObject });
 
@@ -367,13 +353,58 @@ test.describe('dashboard objects', () => {
     });
   });
 
-  test('Delete a Formatted Text Block object', async () => {
+  test('Delete a Formatted Text Block object', async ({
+    dashboardsAdminPage,
+    dashboard,
+    dashboardPage,
+  }) => {
     test.info().annotations.push({
       type: AnnotationType.TestId,
       description: 'Test-768',
     });
 
-    expect(true).toBeTruthy();
+    const formattedTextBlock = new FormattedTextBlock({
+      name: FakeDataFactory.createFakeObjectName(),
+    });
+  
+    await test.step('Navigate to the dashboards admin page', async () => {
+      await dashboardsAdminPage.goto();
+    });
+
+    await test.step('Open the dashboard designer', async () => {
+      await dashboardsAdminPage.openDashboardDesigner(dashboard.name);
+    });
+
+    await test.step('Add a formatted text block object to the dashboard', async () => {
+      await dashboardsAdminPage.dashboardDesigner.addDashboardObject(formattedTextBlock);
+
+      dashboard.items.push({ row: 0, column: 0, item: formattedTextBlock });
+
+      await dashboardsAdminPage.dashboardDesigner.updateDashboard(dashboard);
+      await dashboardsAdminPage.dashboardDesigner.saveAndClose();
+    });
+
+    await test.step('Navigate to the dashboard page', async () => {
+      await dashboardPage.goto(dashboard.id);
+    });
+
+    await test.step('Verify the formatted text block object displays', async () => {
+      const item = dashboardPage.getDashboardItem(formattedTextBlock.name);
+      await expect(item).toBeVisible();
+    });
+
+    await test.step('Delete the formatted text block object', async () => {
+      await dashboardPage.openDashboardDesigner();
+      await dashboardPage.dashboardDesigner.deleteDashboardObject(formattedTextBlock);
+      await dashboardPage.dashboardDesigner.saveAndClose();
+    });
+
+    await test.step('Verify the formatted text block object is deleted', async () => {
+      await dashboardPage.page.reload();
+
+      const item = dashboardPage.getDashboardItem(formattedTextBlock.name);
+      await expect(item).toBeHidden();
+    });
   });
 
   test('Delete a Web Page object', async () => {

--- a/tests/dashboardObjects/dashboardObjects.spec.ts
+++ b/tests/dashboardObjects/dashboardObjects.spec.ts
@@ -215,13 +215,63 @@ test.describe('dashboard objects', () => {
     });
   });
 
-  test('Modify an App Search object', async () => {
+  test('Modify an App Search object', async ({
+    sourceApp,
+    dashboardsAdminPage,
+    dashboard,
+    dashboardPage,
+  }) => {
     test.info().annotations.push({
       type: AnnotationType.TestId,
       description: 'Test-762',
     });
 
-    expect(true).toBeTruthy();
+    const appSearchObject = new AppSearch({
+      name: FakeDataFactory.createFakeObjectName(),
+      apps: [sourceApp.name],
+    });
+
+    await test.step('Navigate to the dashboards admin page', async () => {
+      await dashboardsAdminPage.goto();
+    });
+
+    await test.step('Open the dashboard designer', async () => {
+      await dashboardsAdminPage.openDashboardDesigner(dashboard.name);
+    });
+
+    await test.step('Add an app search object', async () => {
+      await dashboardsAdminPage.dashboardDesigner.addDashboardObject(appSearchObject);
+
+      dashboard.items.push({ row: 0, column: 0, item: appSearchObject });
+
+      await dashboardsAdminPage.dashboardDesigner.updateDashboard(dashboard);
+      await dashboardsAdminPage.dashboardDesigner.saveAndClose();
+    });
+
+    await test.step('Navigate to the dashboard page', async () => {
+      await dashboardPage.goto(dashboard.id);
+    });
+
+    await test.step('Verify the app search object displays', async () => {
+      const item = dashboardPage.getDashboardItem(appSearchObject.name);
+      await expect(item).toBeVisible();
+    });
+    
+    const updatedAppSearchObject = structuredClone(appSearchObject);
+    updatedAppSearchObject.name = FakeDataFactory.createFakeObjectName();
+
+    await test.step('Modify the app search object', async () => {
+      await dashboardPage.openDashboardDesigner();
+      await dashboardPage.dashboardDesigner.updateDashboardObject(appSearchObject, updatedAppSearchObject);
+      await dashboardPage.dashboardDesigner.close();
+    });
+
+    await test.step('Verify the app search object is modified', async () => {
+      await dashboardPage.page.reload();
+
+      const item = dashboardPage.getDashboardItem(updatedAppSearchObject.name);
+      await expect(item).toBeVisible();
+    });
   });
 
   test('Modify a Create Content Links object', async () => {

--- a/tests/dashboardObjects/dashboardObjects.spec.ts
+++ b/tests/dashboardObjects/dashboardObjects.spec.ts
@@ -73,13 +73,41 @@ test.describe('dashboard objects', () => {
     });
   });
 
-  test('Add a Create Content Links object', async () => {
+  test('Add a Create Content Links object', async ({ dashboardsAdminPage, sourceApp, dashboard, dashboardPage }) => {
     test.info().annotations.push({
       type: AnnotationType.TestId,
       description: 'Test-759',
     });
 
-    expect(true).toBeTruthy();
+    const createContentLinksObject = new CreateContentLinks({
+      name: FakeDataFactory.createFakeObjectName(),
+    });
+
+    await test.step('Navigate to the dashboards admin page', async () => {
+      await dashboardsAdminPage.goto();
+    });
+
+    await test.step('Open the dashboard designer', async () => {
+      await dashboardsAdminPage.openDashboardDesigner(dashboard.name);
+    });
+
+    await test.step('Add a create content links object', async () => {
+      await dashboardsAdminPage.dashboardDesigner.addCreateContentLinksObject(createContentLinksObject);
+
+      dashboard.items.push({ row: 0, column: 1, object: createContentLinksObject });
+
+      await dashboardsAdminPage.dashboardDesigner.updateDashboard(dashboard);
+      await dashboardsAdminPage.dashboardDesigner.saveAndClose();
+    });
+
+    await test.step('Navigate to the dashboard page', async () => {
+      await dashboardPage.goto(dashboard.id);
+    });
+
+    await test.step('Verify the create content links object displays', async () => {
+      const item = dashboardPage.getDashboardItem(createContentLinksObject.name);
+      await expect(item).toBeVisible();
+    });
   });
 
   test('Add a Formatted Text Block object', async () => {


### PR DESCRIPTION
closes #213

- **chore: stub out tests**
- **tests: add test for Test-758**
- **tests: wip on Test-759**
- **tests: add test for Test-759**
- **tests: wip**
- **tests: add test for Test-760**
- **tests: add test for Test-761**
- **tests: add test for Test-766 and 767**
- **refactor: extract dashboard object items to base classes**
- **tests: add test for Test-768**
- **tests: add test for Test-769**
- **chore: adds script to count lines**
- **chore: change script name**
- **fix: use correct file extensions**
- **tests: add test for Test-762**
- **tests: add test for Test-763, Test-764, and Test-765**
- **tests: make sure to clean up dashboard objects**
- **tests: add test for Test-770**
- **tests: add test for Test-771**
- **tests: add test for Test-772**
- **tests: add test for Test-773**
