### PR TITLE
chore: address changes in version 34

### DIFF
--- a/componentObjectModels/modals/editGenerateDocumentOutcomeModal.ts
+++ b/componentObjectModels/modals/editGenerateDocumentOutcomeModal.ts
@@ -1,33 +1,23 @@
 import { Locator, Page } from '@playwright/test';
 import { GenerateDocumentOutcome } from '../../models/generateDocumentOutcome';
-import { EditOutcomeModal } from './editOutcomeModal';
+import { EditOutcomeModalWithTabs } from './editOutcomeModalWithTabs';
+import { GenerateDocumentCreationSettingsTab } from '../tabs/generateDocumentCreationSettingsTab';
 
-export class EditGenerateDocumentOutcomeModal extends EditOutcomeModal {
-  private readonly documentSelector: Locator;
-  private readonly fileTypeSelector: Locator;
-  private readonly attachmentFieldSelector: Locator;
+export class EditGenerateDocumentOutcomeModal extends EditOutcomeModalWithTabs {
+  private readonly creationSettingsTabButton: Locator;
+  private readonly creationSettingsTab: GenerateDocumentCreationSettingsTab;
 
   constructor(page: Page) {
     super(page);
-    this.documentSelector = this.modal.locator('.label:has-text("Document") + .data').getByRole('listbox');
-    this.fileTypeSelector = this.modal.locator('.label:has-text("File Type") + .data').getByRole('listbox');
-    this.attachmentFieldSelector = this.modal
-      .locator('.label:has-text("Attachment Field") + .data')
-      .getByRole('listbox');
+
+    this.creationSettingsTabButton = this.modal.getByRole('tab', { name: 'Creation Settings' });
+    this.creationSettingsTab = new GenerateDocumentCreationSettingsTab(this.modal);
   }
 
   async fillOutForm(outcome: GenerateDocumentOutcome) {
     await super.fillOutForm(outcome);
 
-    const page = this.modal.page();
-
-    await this.documentSelector.click();
-    await page.getByRole('option', { name: outcome.document }).click();
-
-    await this.fileTypeSelector.click();
-    await page.getByRole('option', { name: outcome.fileType }).click();
-
-    await this.attachmentFieldSelector.click();
-    await page.getByRole('option', { name: outcome.attachmentField }).click();
+    await this.creationSettingsTabButton.click();
+    await this.creationSettingsTab.fillOutForm(outcome);
   }
 }

--- a/componentObjectModels/tabs/generateDocumentCreationSettingsTab.ts
+++ b/componentObjectModels/tabs/generateDocumentCreationSettingsTab.ts
@@ -1,0 +1,70 @@
+import { Locator } from '@playwright/test';
+import { GenerateDocumentOutcome } from '../../models/generateDocumentOutcome';
+
+export class GenerateDocumentCreationSettingsTab {
+  private readonly creationTypeSection: Locator;
+  private readonly creationConfigurationSection: Locator;
+  private readonly documentTypeSelector: Locator;
+  private readonly documentSelector: Locator;
+  private readonly fileTypeSelector: Locator;
+  private readonly attachmentFieldSelector: Locator;
+
+  constructor(modal: Locator) {
+    this.creationTypeSection = modal.locator('.section', {
+      has: modal.page().getByRole('heading', { name: 'Creation Type' }),
+    });
+
+    this.creationConfigurationSection = modal.locator('.section', {
+      has: modal.page().getByRole('heading', { name: 'Creation Configuration' }),
+    });
+
+    this.documentTypeSelector = this.creationTypeSection
+      .locator('.label:has-text("Document Type") + .data')
+      .getByRole('listbox');
+
+    this.documentSelector = this.creationConfigurationSection
+      .locator('.label:has-text("Document") + .data')
+      .getByRole('listbox');
+
+    this.fileTypeSelector = this.creationConfigurationSection
+      .locator('.label:has-text("File Type") + .data')
+      .getByRole('listbox');
+
+    this.attachmentFieldSelector = this.creationConfigurationSection
+      .locator('.label:has-text("Attachment Field") + .data')
+      .getByRole('listbox');
+  }
+
+  private async selectDocumentType(documentType: string) {
+    await this.documentTypeSelector.click();
+    await this.documentTypeSelector.page().getByRole('option', { name: documentType }).click();
+  }
+
+  private async selectDocument(document: string) {
+    await this.documentSelector.click();
+    await this.documentSelector.page().getByRole('option', { name: document }).click();
+  }
+
+  private async selectFileType(fileType: string) {
+    await this.fileTypeSelector.click();
+    await this.fileTypeSelector.page().getByRole('option', { name: fileType }).click();
+  }
+
+  private async selectAttachmentField(attachmentField: string) {
+    await this.attachmentFieldSelector.click();
+    await this.attachmentFieldSelector.page().getByRole('option', { name: attachmentField }).click();
+  }
+
+  async fillOutForm(outcome: GenerateDocumentOutcome) {
+    await this.selectDocumentType(outcome.documentType);
+
+    if (outcome.documentType === 'Generate Document') {
+      await this.selectDocument(outcome.document);
+      await this.selectFileType(outcome.fileType);
+      await this.selectAttachmentField(outcome.attachmentField);
+      return;
+    }
+
+    throw new Error(`Unsupported document type: ${outcome.constructor.name}`);
+  }
+}

--- a/models/generateDocumentOutcome.ts
+++ b/models/generateDocumentOutcome.ts
@@ -1,22 +1,34 @@
 import { Outcome, OutcomeObject } from './outcome';
 
+type GenerateDocumentType = 'Generate Document' | 'Generate Signature Document(s)';
+
 type FileType = 'Microsoft Word' | 'PDF';
 
 type GenerateDocumentOutcomeObject = Omit<OutcomeObject, 'type'> & {
   document: string;
   fileType: FileType;
   attachmentField: string;
+  documentType?: GenerateDocumentType;
 };
 
 export class GenerateDocumentOutcome extends Outcome {
   readonly document: string;
   readonly fileType: FileType;
   readonly attachmentField: string;
+  readonly documentType: GenerateDocumentType;
 
-  constructor({ status, description, document, fileType, attachmentField }: GenerateDocumentOutcomeObject) {
+  constructor({
+    status,
+    description,
+    document,
+    fileType,
+    attachmentField,
+    documentType = 'Generate Document',
+  }: GenerateDocumentOutcomeObject) {
     super({ type: 'Generate Document', status, description });
     this.document = document;
     this.fileType = fileType;
     this.attachmentField = attachmentField;
+    this.documentType = documentType;
   }
 }

--- a/tests/report/report.spec.ts
+++ b/tests/report/report.spec.ts
@@ -776,6 +776,8 @@ test.describe('report', () => {
 
     test.slow();
 
+    test.fail();
+
     await test.step('Create record in source app', async () => {
       await addContentPage.goto(sourceApp.id);
       await addContentPage.saveRecordButton.click();

--- a/tests/report/report.spec.ts
+++ b/tests/report/report.spec.ts
@@ -776,8 +776,6 @@ test.describe('report', () => {
 
     test.slow();
 
-    test.fail();
-
     await test.step('Create record in source app', async () => {
       await addContentPage.goto(sourceApp.id);
       await addContentPage.saveRecordButton.click();


### PR DESCRIPTION
closes #229

- **feat: refactor document outcome modal and add creation settings tab functionality**
- **chore: mark test as failing**
- **fix: modify locator for include all levels checkbox to use getByRole**
- **chore: remove test.fail() assertion**
