### PR TITLE
tests: add tests for data connectors

### DIFF
--- a/componentObjectModels/tabs/blackKiteConnectionTab.ts
+++ b/componentObjectModels/tabs/blackKiteConnectionTab.ts
@@ -1,0 +1,8 @@
+import { Page } from '../../fixtures';
+import { DataConnectorConnectionTab } from './dataConnectorConnectionTab';
+
+export class BlackKiteConnectionTab extends DataConnectorConnectionTab {
+  constructor(page: Page) {
+    super(page);
+  }
+}

--- a/componentObjectModels/tabs/jiraConnectionTab.ts
+++ b/componentObjectModels/tabs/jiraConnectionTab.ts
@@ -1,0 +1,8 @@
+import { Page } from '../../fixtures';
+import { DataConnectorConnectionTab } from './dataConnectorConnectionTab';
+
+export class JiraConnectionTab extends DataConnectorConnectionTab {
+  constructor(page: Page) {
+    super(page);
+  }
+}

--- a/componentObjectModels/tabs/rapidRatingsConnectionTab.ts
+++ b/componentObjectModels/tabs/rapidRatingsConnectionTab.ts
@@ -1,0 +1,8 @@
+import { Page } from '../../fixtures';
+import { DataConnectorConnectionTab } from './dataConnectorConnectionTab';
+
+export class RapidRatingsConnectionTab extends DataConnectorConnectionTab {
+  constructor(page: Page) {
+    super(page);
+  }
+}

--- a/componentObjectModels/tabs/regologyConnectionTab.ts
+++ b/componentObjectModels/tabs/regologyConnectionTab.ts
@@ -1,0 +1,8 @@
+import { Page } from '../../fixtures';
+import { DataConnectorConnectionTab } from './dataConnectorConnectionTab';
+
+export class RegologyConnectionTab extends DataConnectorConnectionTab {
+  constructor(page: Page) {
+    super(page);
+  }
+}

--- a/componentObjectModels/tabs/riskReconConnectionTab.ts
+++ b/componentObjectModels/tabs/riskReconConnectionTab.ts
@@ -1,0 +1,8 @@
+import { Page } from '../../fixtures';
+import { DataConnectorConnectionTab } from './dataConnectorConnectionTab';
+
+export class RiskReconConnectionTab extends DataConnectorConnectionTab {
+  constructor(page: Page) {
+    super(page);
+  }
+}

--- a/componentObjectModels/tabs/securityScorecardConnectionTab.ts
+++ b/componentObjectModels/tabs/securityScorecardConnectionTab.ts
@@ -1,0 +1,8 @@
+import { Page } from '../../fixtures';
+import { DataConnectorConnectionTab } from './dataConnectorConnectionTab';
+
+export class SecurityScorecardConnectionTab extends DataConnectorConnectionTab {
+  constructor(page: Page) {
+    super(page);
+  }
+}

--- a/componentObjectModels/tabs/slackConnectorGeneralTab.ts
+++ b/componentObjectModels/tabs/slackConnectorGeneralTab.ts
@@ -1,0 +1,8 @@
+import { Page } from '../../fixtures';
+import { DataConnectorConnectionTab } from './dataConnectorConnectionTab';
+
+export class SlackConnectorGeneralTab extends DataConnectorConnectionTab {
+  constructor(page: Page) {
+    super(page);
+  }
+}

--- a/componentObjectModels/tabs/ucfConnectionTab.ts
+++ b/componentObjectModels/tabs/ucfConnectionTab.ts
@@ -1,0 +1,8 @@
+import { Page } from '../../fixtures';
+import { DataConnectorConnectionTab } from './dataConnectorConnectionTab';
+
+export class UcfConnectionTab extends DataConnectorConnectionTab {
+  constructor(page: Page) {
+    super(page);
+  }
+}

--- a/pageObjectModels/dataConnectors/editBitsightConnectorPage.ts
+++ b/pageObjectModels/dataConnectors/editBitsightConnectorPage.ts
@@ -8,6 +8,7 @@ import { EditConnectorPage } from './editConnectorPage';
 
 export class EditBitsightConnectorPage extends EditConnectorPage {
   private readonly savePath: RegExp;
+  readonly connectionTabButton: Locator;
   readonly appMappingTabButton: Locator;
   readonly dataMappingTabButton: Locator;
   readonly schedulingTabButton: Locator;
@@ -19,13 +20,14 @@ export class EditBitsightConnectorPage extends EditConnectorPage {
   constructor(page: Page) {
     super(page);
     this.savePath = /\/Admin\/Integration\/DataConnector\/EditBitsightConnector/;
-    this.appMappingTabButton = page.getByRole('tab', { name: /app mapping/i });
-    this.dataMappingTabButton = page.getByRole('tab', { name: /data mapping/i });
-    this.schedulingTabButton = page.getByRole('tab', { name: /scheduling/i });
-    this.connectionTab = new BitsightConnectionTab(page);
-    this.appMappingTab = new BitsightAppMappingTab(page);
-    this.dataMappingTab = new BitsightDataMapping(page);
-    this.schedulingTab = new BitsightSchedulingTab(page);
+    this.connectionTabButton = this.page.getByRole('tab', { name: /connection/i });
+    this.appMappingTabButton = this.page.getByRole('tab', { name: /app mapping/i });
+    this.dataMappingTabButton = this.page.getByRole('tab', { name: /data mapping/i });
+    this.schedulingTabButton = this.page.getByRole('tab', { name: /scheduling/i });
+    this.connectionTab = new BitsightConnectionTab(this.page);
+    this.appMappingTab = new BitsightAppMappingTab(this.page);
+    this.dataMappingTab = new BitsightDataMapping(this.page);
+    this.schedulingTab = new BitsightSchedulingTab(this.page);
   }
 
   private async save() {

--- a/pageObjectModels/dataConnectors/editBlackKiteConnectorPage.ts
+++ b/pageObjectModels/dataConnectors/editBlackKiteConnectorPage.ts
@@ -1,0 +1,12 @@
+import { BlackKiteConnectionTab } from '../../componentObjectModels/tabs/blackKiteConnectionTab';
+import { Page } from '../../fixtures';
+import { EditConnectorPage } from './editConnectorPage';
+
+export class EditBlackKiteConnectorPage extends EditConnectorPage {
+  readonly connectionTab: BlackKiteConnectionTab;
+
+  constructor(page: Page) {
+    super(page);
+    this.connectionTab = new BlackKiteConnectionTab(this.page);
+  }
+}

--- a/pageObjectModels/dataConnectors/editConnectorPage.ts
+++ b/pageObjectModels/dataConnectors/editConnectorPage.ts
@@ -8,7 +8,7 @@ export abstract class EditConnectorPage extends BaseAdminPage {
   constructor(page: Page) {
     super(page);
     this.pathRegex = /\/Admin\/Integration\/DataConnector\/\d+\/Edit/;
-    this.saveButton = page.getByRole('link', { name: 'Save Changes' });
+    this.saveButton = this.page.getByRole('link', { name: 'Save Changes' });
   }
 
   async goto(id: number) {

--- a/pageObjectModels/dataConnectors/editConnectorPage.ts
+++ b/pageObjectModels/dataConnectors/editConnectorPage.ts
@@ -1,18 +1,14 @@
 import { Locator, Page } from '@playwright/test';
-import { DataConnectorConnectionTab } from '../../componentObjectModels/tabs/dataConnectorConnectionTab';
 import { BaseAdminPage } from '../baseAdminPage';
 
 export abstract class EditConnectorPage extends BaseAdminPage {
   readonly pathRegex: RegExp;
   protected readonly saveButton: Locator;
-  readonly connectionTabButton: Locator;
-  abstract readonly connectionTab: DataConnectorConnectionTab;
 
   constructor(page: Page) {
     super(page);
     this.pathRegex = /\/Admin\/Integration\/DataConnector\/\d+\/Edit/;
     this.saveButton = page.getByRole('link', { name: 'Save Changes' });
-    this.connectionTabButton = page.getByRole('tab', { name: 'Connection' });
   }
 
   async goto(id: number) {

--- a/pageObjectModels/dataConnectors/editJiraConnectorPage.ts
+++ b/pageObjectModels/dataConnectors/editJiraConnectorPage.ts
@@ -1,0 +1,12 @@
+import { Page } from '@playwright/test';
+import { JiraConnectionTab } from '../../componentObjectModels/tabs/jiraConnectionTab';
+import { EditConnectorPage } from './editConnectorPage';
+
+export class EditJiraConnectorPage extends EditConnectorPage {
+  readonly connectionTab: JiraConnectionTab;
+
+  constructor(page: Page) {
+    super(page);
+    this.connectionTab = new JiraConnectionTab(this.page);
+  }
+}

--- a/pageObjectModels/dataConnectors/editRapidRatingsConnectorPage.ts
+++ b/pageObjectModels/dataConnectors/editRapidRatingsConnectorPage.ts
@@ -1,0 +1,12 @@
+import { RapidRatingsConnectionTab } from '../../componentObjectModels/tabs/rapidRatingsConnectionTab';
+import { Page } from '../../fixtures';
+import { EditConnectorPage } from './editConnectorPage';
+
+export class EditRapidRatingsConnectorPage extends EditConnectorPage {
+  readonly connectionTab: RapidRatingsConnectionTab;
+
+  constructor(page: Page) {
+    super(page);
+    this.connectionTab = new RapidRatingsConnectionTab(this.page);
+  }
+}

--- a/pageObjectModels/dataConnectors/editRegologyConnectorPage.ts
+++ b/pageObjectModels/dataConnectors/editRegologyConnectorPage.ts
@@ -1,0 +1,12 @@
+import { RegologyConnectionTab } from '../../componentObjectModels/tabs/regologyConnectionTab';
+import { Page } from '../../fixtures';
+import { EditConnectorPage } from './editConnectorPage';
+
+export class EditRegologyConnectorPage extends EditConnectorPage {
+  readonly connectionTab: RegologyConnectionTab;
+
+  constructor(page: Page) {
+    super(page);
+    this.connectionTab = new RegologyConnectionTab(this.page);
+  }
+}

--- a/pageObjectModels/dataConnectors/editRiskReconConnectorPage.ts
+++ b/pageObjectModels/dataConnectors/editRiskReconConnectorPage.ts
@@ -1,0 +1,12 @@
+import { RiskReconConnectionTab } from '../../componentObjectModels/tabs/riskReconConnectionTab';
+import { Page } from '../../fixtures';
+import { EditConnectorPage } from './editConnectorPage';
+
+export class EditRiskReconConnectorPage extends EditConnectorPage {
+  readonly connectionTab: RiskReconConnectionTab;
+
+  constructor(page: Page) {
+    super(page);
+    this.connectionTab = new RiskReconConnectionTab(page);
+  }
+}

--- a/pageObjectModels/dataConnectors/editRiskReconConnectorPage.ts
+++ b/pageObjectModels/dataConnectors/editRiskReconConnectorPage.ts
@@ -7,6 +7,6 @@ export class EditRiskReconConnectorPage extends EditConnectorPage {
 
   constructor(page: Page) {
     super(page);
-    this.connectionTab = new RiskReconConnectionTab(page);
+    this.connectionTab = new RiskReconConnectionTab(this.page);
   }
 }

--- a/pageObjectModels/dataConnectors/editSecureFileDataConnectorPage.ts
+++ b/pageObjectModels/dataConnectors/editSecureFileDataConnectorPage.ts
@@ -20,14 +20,14 @@ export class EditSecureFileDataConnectorPage extends EditConnectorPage {
   constructor(page: Page) {
     super(page);
     this.savePath = '/Admin/Integration/DataConnector/EditSecureFile';
-    this.connectionTabButton = page.getByRole('tab', { name: 'Connection' });
-    this.connectionTab = new SecureFileConnectionTab(page);
-    this.dataMappingTabButton = page.getByRole('tab', { name: 'Data Mapping' });
-    this.dataMappingTab = new SecureFileDataMappingTab(page);
-    this.integrationSettingsTabButton = page.getByRole('tab', { name: 'Integration Settings' });
-    this.integrationSettingsTab = new SecureFileIntegrationSettingsTab(page);
-    this.schedulingTabButton = page.getByRole('tab', { name: 'Scheduling' });
-    this.schedulingTab = new SecureFileSchedulingTab(page);
+    this.connectionTabButton = this.page.getByRole('tab', { name: 'Connection' });
+    this.connectionTab = new SecureFileConnectionTab(this.page);
+    this.dataMappingTabButton = this.page.getByRole('tab', { name: 'Data Mapping' });
+    this.dataMappingTab = new SecureFileDataMappingTab(this.page);
+    this.integrationSettingsTabButton = this.page.getByRole('tab', { name: 'Integration Settings' });
+    this.integrationSettingsTab = new SecureFileIntegrationSettingsTab(this.page);
+    this.schedulingTabButton = this.page.getByRole('tab', { name: 'Scheduling' });
+    this.schedulingTab = new SecureFileSchedulingTab(this.page);
   }
 
   private async save() {

--- a/pageObjectModels/dataConnectors/editSecurityScorecardConnectorPage.ts
+++ b/pageObjectModels/dataConnectors/editSecurityScorecardConnectorPage.ts
@@ -1,0 +1,12 @@
+import { SecurityScorecardConnectionTab } from '../../componentObjectModels/tabs/securityScorecardConnectionTab';
+import { Page } from '../../fixtures';
+import { EditConnectorPage } from './editConnectorPage';
+
+export class EditSecurityScorecardConnectorPage extends EditConnectorPage {
+  readonly connectionTab: SecurityScorecardConnectionTab;
+
+  constructor(page: Page) {
+    super(page);
+    this.connectionTab = new SecurityScorecardConnectionTab(page);
+  }
+}

--- a/pageObjectModels/dataConnectors/editSecurityScorecardConnectorPage.ts
+++ b/pageObjectModels/dataConnectors/editSecurityScorecardConnectorPage.ts
@@ -7,6 +7,6 @@ export class EditSecurityScorecardConnectorPage extends EditConnectorPage {
 
   constructor(page: Page) {
     super(page);
-    this.connectionTab = new SecurityScorecardConnectionTab(page);
+    this.connectionTab = new SecurityScorecardConnectionTab(this.page);
   }
 }

--- a/pageObjectModels/dataConnectors/editSlackConnectorPage.ts
+++ b/pageObjectModels/dataConnectors/editSlackConnectorPage.ts
@@ -1,0 +1,12 @@
+import { SlackConnectorGeneralTab } from '../../componentObjectModels/tabs/slackConnectorGeneralTab';
+import { Page } from '../../fixtures';
+import { EditConnectorPage } from './editConnectorPage';
+
+export class EditSlackConnectorPage extends EditConnectorPage {
+  generalTab: SlackConnectorGeneralTab;
+
+  constructor(page: Page) {
+    super(page);
+    this.generalTab = new SlackConnectorGeneralTab(page);
+  }
+}

--- a/pageObjectModels/dataConnectors/editSlackConnectorPage.ts
+++ b/pageObjectModels/dataConnectors/editSlackConnectorPage.ts
@@ -7,6 +7,6 @@ export class EditSlackConnectorPage extends EditConnectorPage {
 
   constructor(page: Page) {
     super(page);
-    this.generalTab = new SlackConnectorGeneralTab(page);
+    this.generalTab = new SlackConnectorGeneralTab(this.page);
   }
 }

--- a/pageObjectModels/dataConnectors/editUcfConnectorPage.ts
+++ b/pageObjectModels/dataConnectors/editUcfConnectorPage.ts
@@ -1,0 +1,12 @@
+import { UcfConnectionTab } from '../../componentObjectModels/tabs/ucfConnectionTab';
+import { Page } from '../../fixtures';
+import { EditConnectorPage } from './editConnectorPage';
+
+export class EditUcfConnectorPage extends EditConnectorPage {
+  connectionTab: UcfConnectionTab;
+
+  constructor(page: Page) {
+    super(page);
+    this.connectionTab = new UcfConnectionTab(page);
+  }
+}

--- a/pageObjectModels/dataConnectors/editUcfConnectorPage.ts
+++ b/pageObjectModels/dataConnectors/editUcfConnectorPage.ts
@@ -7,6 +7,6 @@ export class EditUcfConnectorPage extends EditConnectorPage {
 
   constructor(page: Page) {
     super(page);
-    this.connectionTab = new UcfConnectionTab(page);
+    this.connectionTab = new UcfConnectionTab(this.page);
   }
 }

--- a/tests/dataConnector/blackKite.spec.ts
+++ b/tests/dataConnector/blackKite.spec.ts
@@ -1,0 +1,112 @@
+import { FakeDataFactory } from '../../factories/fakeDataFactory';
+import { test as base, expect } from '../../fixtures';
+import { DataConnectorAdminPage } from '../../pageObjectModels/dataConnectors/dataConnectorAdminPage';
+import { EditBlackKiteConnectorPage } from '../../pageObjectModels/dataConnectors/editBlackKiteConnectorPage';
+import { AnnotationType } from '../annotations';
+
+type BlackKiteDataConnectorTestFixtures = {
+  dataConnectorAdminPage: DataConnectorAdminPage;
+  editBlackKiteConnectorPage: EditBlackKiteConnectorPage;
+};
+
+const test = base.extend<BlackKiteDataConnectorTestFixtures>({
+  dataConnectorAdminPage: async ({ sysAdminPage }, use) => await use(new DataConnectorAdminPage(sysAdminPage)),
+  editBlackKiteConnectorPage: async ({ sysAdminPage }, use) => await use(new EditBlackKiteConnectorPage(sysAdminPage)),
+});
+
+test.describe('black kite data connector', () => {
+  let connectorsToDelete: string[] = [];
+
+  test.afterEach(async ({ dataConnectorAdminPage }) => {
+    await dataConnectorAdminPage.deleteConnectors(connectorsToDelete);
+    connectorsToDelete = [];
+  });
+
+  test('Create a new Black Kite connector', async ({ dataConnectorAdminPage, editBlackKiteConnectorPage }) => {
+    test.info().annotations.push({
+      type: AnnotationType.TestId,
+      description: 'Test-840',
+    });
+
+    const connectorName = FakeDataFactory.createFakeConnectorName();
+    connectorsToDelete.push(connectorName);
+
+    await test.step('Navigate to the data connectors admin page', async () => {
+      await dataConnectorAdminPage.goto();
+    });
+
+    await test.step('Create the black kite data connector', async () => {
+      await dataConnectorAdminPage.createConnector(connectorName, 'Black Kite Data Connector');
+      await dataConnectorAdminPage.page.waitForURL(editBlackKiteConnectorPage.pathRegex);
+    });
+
+    await test.step('Verify the data connector was created successfully', async () => {
+      await expect(editBlackKiteConnectorPage.connectionTab.nameInput).toHaveValue(connectorName);
+    });
+  });
+
+  test('Create a copy of a Black Kite connector', async ({ dataConnectorAdminPage, editBlackKiteConnectorPage }) => {
+    test.info().annotations.push({
+      type: AnnotationType.TestId,
+      description: 'Test-841',
+    });
+
+    const connectorToCopyName = FakeDataFactory.createFakeConnectorName();
+    const connectorCopyName = FakeDataFactory.createFakeConnectorName();
+    connectorsToDelete.push(connectorToCopyName, connectorCopyName);
+
+    await test.step('Navigate to the data connectors admin page', async () => {
+      await dataConnectorAdminPage.goto();
+    });
+
+    await test.step('Create the black kite data connector to copy', async () => {
+      await dataConnectorAdminPage.createConnector(connectorToCopyName, 'Black Kite Data Connector');
+      await dataConnectorAdminPage.page.waitForURL(editBlackKiteConnectorPage.pathRegex);
+    });
+
+    await test.step('Navigate back to the data connectors admin page', async () => {
+      await dataConnectorAdminPage.goto();
+    });
+
+    await test.step('Create a copy of the black site data connector', async () => {
+      await dataConnectorAdminPage.copyConnector('Black Kite Data Connector', connectorToCopyName, connectorCopyName);
+      await dataConnectorAdminPage.page.waitForURL(editBlackKiteConnectorPage.pathRegex);
+    });
+
+    await test.step('Verify the data connector was created successfully', async () => {
+      await expect(editBlackKiteConnectorPage.connectionTab.nameInput).toHaveValue(connectorCopyName);
+    });
+  });
+
+  test('Delete a Black Kite connector', async ({ dataConnectorAdminPage, editBlackKiteConnectorPage }) => {
+    test.info().annotations.push({
+      type: AnnotationType.TestId,
+      description: 'Test-842',
+    });
+
+    const connectorName = FakeDataFactory.createFakeConnectorName();
+
+    await test.step('Navigate to the data connectors admin page', async () => {
+      await dataConnectorAdminPage.goto();
+    });
+
+    await test.step('Create the data connector to delete', async () => {
+      await dataConnectorAdminPage.createConnector(connectorName, 'Black Kite Data Connector');
+      await dataConnectorAdminPage.page.waitForURL(editBlackKiteConnectorPage.pathRegex);
+    });
+
+    await test.step('Navigate back to the data connectors admin page', async () => {
+      await dataConnectorAdminPage.goto();
+    });
+
+    await test.step('Delete the data connector', async () => {
+      await dataConnectorAdminPage.deleteConnector(connectorName);
+    });
+
+    await test.step('Verify the data connector has been deleted', async () => {
+      const connectorRow = dataConnectorAdminPage.connectorsGrid.getByRole('row', { name: connectorName });
+
+      await expect(connectorRow).toBeHidden();
+    });
+  });
+});

--- a/tests/dataConnector/jira.spec.ts
+++ b/tests/dataConnector/jira.spec.ts
@@ -1,0 +1,112 @@
+import { FakeDataFactory } from '../../factories/fakeDataFactory';
+import { test as base, expect } from '../../fixtures';
+import { DataConnectorAdminPage } from '../../pageObjectModels/dataConnectors/dataConnectorAdminPage';
+import { EditJiraConnectorPage } from '../../pageObjectModels/dataConnectors/editJiraConnectorPage';
+import { AnnotationType } from '../annotations';
+
+type JiraDataConnectorTestFixtures = {
+  dataConnectorAdminPage: DataConnectorAdminPage;
+  editJiraConnectorPage: EditJiraConnectorPage;
+};
+
+const test = base.extend<JiraDataConnectorTestFixtures>({
+  dataConnectorAdminPage: async ({ sysAdminPage }, use) => await use(new DataConnectorAdminPage(sysAdminPage)),
+  editJiraConnectorPage: async ({ sysAdminPage }, use) => await use(new EditJiraConnectorPage(sysAdminPage)),
+});
+
+test.describe('jira data connector', () => {
+  let connectorsToDelete: string[] = [];
+
+  test.afterEach(async ({ dataConnectorAdminPage }) => {
+    await dataConnectorAdminPage.deleteConnectors(connectorsToDelete);
+    connectorsToDelete = [];
+  });
+
+  test('Create a new Jira connector', async ({ dataConnectorAdminPage, editJiraConnectorPage }) => {
+    test.info().annotations.push({
+      type: AnnotationType.TestId,
+      description: 'Test-416',
+    });
+
+    const connectorName = FakeDataFactory.createFakeConnectorName();
+    connectorsToDelete.push(connectorName);
+
+    await test.step('Navigate to the data connectors admin page', async () => {
+      await dataConnectorAdminPage.goto();
+    });
+
+    await test.step('Create the jira data connector', async () => {
+      await dataConnectorAdminPage.createConnector(connectorName, 'Jira Data Connector');
+      await dataConnectorAdminPage.page.waitForURL(editJiraConnectorPage.pathRegex);
+    });
+
+    await test.step('Verify the data connector was created successfully', async () => {
+      await expect(editJiraConnectorPage.connectionTab.nameInput).toHaveValue(connectorName);
+    });
+  });
+
+  test('Create a copy of a Jira connector', async ({ dataConnectorAdminPage, editJiraConnectorPage }) => {
+    test.info().annotations.push({
+      type: AnnotationType.TestId,
+      description: 'Test-417',
+    });
+
+    const connectorToCopyName = FakeDataFactory.createFakeConnectorName();
+    const connectorCopyName = FakeDataFactory.createFakeConnectorName();
+    connectorsToDelete.push(connectorToCopyName, connectorCopyName);
+
+    await test.step('Navigate to the data connectors admin page', async () => {
+      await dataConnectorAdminPage.goto();
+    });
+
+    await test.step('Create the jira data connector to copy', async () => {
+      await dataConnectorAdminPage.createConnector(connectorToCopyName, 'Jira Data Connector');
+      await dataConnectorAdminPage.page.waitForURL(editJiraConnectorPage.pathRegex);
+    });
+
+    await test.step('Navigate back to the data connectors admin page', async () => {
+      await dataConnectorAdminPage.goto();
+    });
+
+    await test.step('Create a copy of the jira data connector', async () => {
+      await dataConnectorAdminPage.copyConnector('Jira Data Connector', connectorToCopyName, connectorCopyName);
+      await dataConnectorAdminPage.page.waitForURL(editJiraConnectorPage.pathRegex);
+    });
+
+    await test.step('Verify the data connector was created successfully', async () => {
+      await expect(editJiraConnectorPage.connectionTab.nameInput).toHaveValue(connectorCopyName);
+    });
+  });
+
+  test('Delete a Jira connector', async ({ dataConnectorAdminPage, editJiraConnectorPage }) => {
+    test.info().annotations.push({
+      type: AnnotationType.TestId,
+      description: 'Test-418',
+    });
+
+    const connectorName = FakeDataFactory.createFakeConnectorName();
+
+    await test.step('Navigate to the data connectors admin page', async () => {
+      await dataConnectorAdminPage.goto();
+    });
+
+    await test.step('Create the data connector to delete', async () => {
+      await dataConnectorAdminPage.createConnector(connectorName, 'Jira Data Connector');
+      await dataConnectorAdminPage.page.waitForURL(editJiraConnectorPage.pathRegex);
+    });
+
+    await test.step('Navigate back to the data connectors admin page', async () => {
+      await dataConnectorAdminPage.goto();
+    });
+
+    await test.step('Delete the data connector', async () => {
+      await dataConnectorAdminPage.deleteConnector(connectorName);
+    });
+
+    await test.step('Verify the data connector has been deleted', async () => {
+      const connectorRow = dataConnectorAdminPage.connectorsGrid.getByRole('row', { name: connectorName });
+
+      await expect(connectorRow).toBeHidden();
+    });
+  });
+});

--- a/tests/dataConnector/rapidRatings.spec.ts
+++ b/tests/dataConnector/rapidRatings.spec.ts
@@ -1,0 +1,66 @@
+import { FakeDataFactory } from '../../factories/fakeDataFactory';
+import { test as base, expect } from '../../fixtures';
+import { DataConnectorAdminPage } from '../../pageObjectModels/dataConnectors/dataConnectorAdminPage';
+import { EditRapidRatingsConnectorPage } from '../../pageObjectModels/dataConnectors/editRapidRatingsConnectorPage';
+import { AnnotationType } from '../annotations';
+
+type RapidRatingsDataConnectorTestFixtures = {
+  dataConnectorAdminPage: DataConnectorAdminPage;
+  editRapidRatingsConnectorPage: EditRapidRatingsConnectorPage;
+};
+
+const test = base.extend<RapidRatingsDataConnectorTestFixtures>({
+  dataConnectorAdminPage: async ({ sysAdminPage }, use) => await use(new DataConnectorAdminPage(sysAdminPage)),
+  editRapidRatingsConnectorPage: async ({ sysAdminPage }, use) =>
+    await use(new EditRapidRatingsConnectorPage(sysAdminPage)),
+});
+
+test.describe('rapid ratings data connector', () => {
+  let connectorsToDelete: string[] = [];
+
+  test.afterEach(async ({ dataConnectorAdminPage }) => {
+    await dataConnectorAdminPage.deleteConnectors(connectorsToDelete);
+    connectorsToDelete = [];
+  });
+
+  test('Create a new RapidRatings connector', async ({ dataConnectorAdminPage, editRapidRatingsConnectorPage }) => {
+    test.info().annotations.push({
+      type: AnnotationType.TestId,
+      description: 'Test-402',
+    });
+
+    const connectorName = FakeDataFactory.createFakeConnectorName();
+    connectorsToDelete.push(connectorName);
+
+    await test.step('Navigate to the data connectors admin page', async () => {
+      await dataConnectorAdminPage.goto();
+    });
+
+    await test.step('Create the rapid ratings data connector', async () => {
+      await dataConnectorAdminPage.createConnector(connectorName, 'RapidRatings Data Connector');
+      await dataConnectorAdminPage.page.waitForURL(editRapidRatingsConnectorPage.pathRegex);
+    });
+
+    await test.step('Verify the data connector was created successfully', async () => {
+      await expect(editRapidRatingsConnectorPage.connectionTab.nameInput).toHaveValue(connectorName);
+    });
+  });
+
+  test('Create a copy of a RapidRatings connector', async () => {
+    test.info().annotations.push({
+      type: AnnotationType.TestId,
+      description: 'Test-403',
+    });
+
+    expect(true).toBeTruthy();
+  });
+
+  test('Delete a RapidRatings connector', async () => {
+    test.info().annotations.push({
+      type: AnnotationType.TestId,
+      description: 'Test-404',
+    });
+
+    expect(true).toBeTruthy();
+  });
+});

--- a/tests/dataConnector/rapidRatings.spec.ts
+++ b/tests/dataConnector/rapidRatings.spec.ts
@@ -82,12 +82,35 @@ test.describe('rapid ratings data connector', () => {
     });
   });
 
-  test('Delete a RapidRatings connector', async () => {
+  test('Delete a RapidRatings connector', async ({ dataConnectorAdminPage, editRapidRatingsConnectorPage }) => {
     test.info().annotations.push({
       type: AnnotationType.TestId,
       description: 'Test-404',
     });
 
-    expect(true).toBeTruthy();
+    const connectorName = FakeDataFactory.createFakeConnectorName();
+
+    await test.step('Navigate to the data connectors admin page', async () => {
+      await dataConnectorAdminPage.goto();
+    });
+
+    await test.step('Create the data connector to delete', async () => {
+      await dataConnectorAdminPage.createConnector(connectorName, 'RapidRatings Data Connector');
+      await dataConnectorAdminPage.page.waitForURL(editRapidRatingsConnectorPage.pathRegex);
+    });
+
+    await test.step('Navigate back to the data connectors admin page', async () => {
+      await dataConnectorAdminPage.goto();
+    });
+
+    await test.step('Delete the data connector', async () => {
+      await dataConnectorAdminPage.deleteConnector(connectorName);
+    });
+
+    await test.step('Verify the data connector has been deleted', async () => {
+      const connectorRow = dataConnectorAdminPage.connectorsGrid.getByRole('row', { name: connectorName });
+
+      await expect(connectorRow).toBeHidden();
+    });
   });
 });

--- a/tests/dataConnector/rapidRatings.spec.ts
+++ b/tests/dataConnector/rapidRatings.spec.ts
@@ -46,13 +46,40 @@ test.describe('rapid ratings data connector', () => {
     });
   });
 
-  test('Create a copy of a RapidRatings connector', async () => {
+  test('Create a copy of a RapidRatings connector', async ({
+    dataConnectorAdminPage,
+    editRapidRatingsConnectorPage,
+  }) => {
     test.info().annotations.push({
       type: AnnotationType.TestId,
       description: 'Test-403',
     });
 
-    expect(true).toBeTruthy();
+    const connectorToCopyName = FakeDataFactory.createFakeConnectorName();
+    const connectorCopyName = FakeDataFactory.createFakeConnectorName();
+    connectorsToDelete.push(connectorToCopyName, connectorCopyName);
+
+    await test.step('Navigate to the data connectors admin page', async () => {
+      await dataConnectorAdminPage.goto();
+    });
+
+    await test.step('Create the rapid ratings data connector to copy', async () => {
+      await dataConnectorAdminPage.createConnector(connectorToCopyName, 'RapidRatings Data Connector');
+      await dataConnectorAdminPage.page.waitForURL(editRapidRatingsConnectorPage.pathRegex);
+    });
+
+    await test.step('Navigate back to the data connectors admin page', async () => {
+      await dataConnectorAdminPage.goto();
+    });
+
+    await test.step('Create a copy of the rapid ratings data connector', async () => {
+      await dataConnectorAdminPage.copyConnector('RapidRatings Data Connector', connectorToCopyName, connectorCopyName);
+      await dataConnectorAdminPage.page.waitForURL(editRapidRatingsConnectorPage.pathRegex);
+    });
+
+    await test.step('Verify the data connector was created successfully', async () => {
+      await expect(editRapidRatingsConnectorPage.connectionTab.nameInput).toHaveValue(connectorCopyName);
+    });
   });
 
   test('Delete a RapidRatings connector', async () => {

--- a/tests/dataConnector/regology.spec.ts
+++ b/tests/dataConnector/regology.spec.ts
@@ -1,0 +1,35 @@
+import { test as base, expect } from '../../fixtures';
+import { AnnotationType } from '../annotations';
+
+type RegologyDataConnectorTestFixtures = {};
+
+const test = base.extend<RegologyDataConnectorTestFixtures>({});
+
+test.describe('regology data connector', () => {
+  test('Create a new Regology connector', async () => {
+    test.info().annotations.push({
+      type: AnnotationType.TestId,
+      description: 'Test-846',
+    });
+
+    expect(true).toBeTruthy();
+  });
+
+  test('Create a copy of a Regology connector', async () => {
+    test.info().annotations.push({
+      type: AnnotationType.TestId,
+      description: 'Test-847',
+    });
+
+    expect(true).toBeTruthy();
+  });
+
+  test('Delete a Regology connector', async () => {
+    test.info().annotations.push({
+      type: AnnotationType.TestId,
+      description: 'Test-848',
+    });
+
+    expect(true).toBeTruthy();
+  });
+});

--- a/tests/dataConnector/regology.spec.ts
+++ b/tests/dataConnector/regology.spec.ts
@@ -35,8 +35,8 @@ test.describe('regology data connector', () => {
       await dataConnectorAdminPage.goto();
     });
 
-    await test.step('Create the risk recon data connector', async () => {
-      await dataConnectorAdminPage.createConnector(connectorName, 'Risk Recon Data Connector');
+    await test.step('Create the regology data connector', async () => {
+      await dataConnectorAdminPage.createConnector(connectorName, 'Regology Data Connector');
       await dataConnectorAdminPage.page.waitForURL(editRegologyConnectorPage.pathRegex);
     });
 
@@ -45,21 +45,68 @@ test.describe('regology data connector', () => {
     });
   });
 
-  test('Create a copy of a Regology connector', async () => {
+  test('Create a copy of a Regology connector', async ({ dataConnectorAdminPage, editRegologyConnectorPage }) => {
     test.info().annotations.push({
       type: AnnotationType.TestId,
       description: 'Test-847',
     });
 
-    expect(true).toBeTruthy();
+    const connectorToCopyName = FakeDataFactory.createFakeConnectorName();
+    const connectorCopyName = FakeDataFactory.createFakeConnectorName();
+    connectorsToDelete.push(connectorToCopyName, connectorCopyName);
+
+    await test.step('Navigate to the data connectors admin page', async () => {
+      await dataConnectorAdminPage.goto();
+    });
+
+    await test.step('Create the regology data connector to copy', async () => {
+      await dataConnectorAdminPage.createConnector(connectorToCopyName, 'Regology Data Connector');
+      await dataConnectorAdminPage.page.waitForURL(editRegologyConnectorPage.pathRegex);
+    });
+
+    await test.step('Navigate back to the data connectors admin page', async () => {
+      await dataConnectorAdminPage.goto();
+    });
+
+    await test.step('Create a copy of the regology data connector', async () => {
+      await dataConnectorAdminPage.copyConnector('Regology Data Connector', connectorToCopyName, connectorCopyName);
+      await dataConnectorAdminPage.page.waitForURL(editRegologyConnectorPage.pathRegex);
+    });
+
+    await test.step('Verify the data connector was created successfully', async () => {
+      await expect(editRegologyConnectorPage.connectionTab.nameInput).toHaveValue(connectorCopyName);
+    });
   });
 
-  test('Delete a Regology connector', async () => {
+  test('Delete a Regology connector', async ({ dataConnectorAdminPage, editRegologyConnectorPage }) => {
     test.info().annotations.push({
       type: AnnotationType.TestId,
       description: 'Test-848',
     });
 
-    expect(true).toBeTruthy();
+    const connectorName = FakeDataFactory.createFakeConnectorName();
+
+    await test.step('Navigate to the data connectors admin page', async () => {
+      await dataConnectorAdminPage.goto();
+    });
+
+    await test.step('Create the data connector to delete', async () => {
+      await dataConnectorAdminPage.createConnector(connectorName, 'Regology Data Connector');
+      await dataConnectorAdminPage.page.waitForURL(editRegologyConnectorPage.pathRegex);
+    });
+
+    await test.step('Navigate back to the data connectors admin page', async () => {
+      await dataConnectorAdminPage.goto();
+    });
+
+    await test.step('Delete the data connector', async () => {
+      await dataConnectorAdminPage.deleteConnector(connectorName);
+    });
+
+    await test.step('Verify the data connector has been deleted', async () => {
+      const connectorRow = dataConnectorAdminPage.connectorsGrid.getByRole('row', { name: connectorName });
+
+      await expect(connectorRow).toBeHidden();
+    });
   });
 });

--- a/tests/dataConnector/regology.spec.ts
+++ b/tests/dataConnector/regology.spec.ts
@@ -1,18 +1,48 @@
+import { FakeDataFactory } from '../../factories/fakeDataFactory';
 import { test as base, expect } from '../../fixtures';
+import { DataConnectorAdminPage } from '../../pageObjectModels/dataConnectors/dataConnectorAdminPage';
+import { EditRegologyConnectorPage } from '../../pageObjectModels/dataConnectors/editRegologyConnectorPage';
 import { AnnotationType } from '../annotations';
 
-type RegologyDataConnectorTestFixtures = {};
+export type RegologyDataConnectorTestFixtures = {
+  dataConnectorAdminPage: DataConnectorAdminPage;
+  editRegologyConnectorPage: EditRegologyConnectorPage;
+};
 
-const test = base.extend<RegologyDataConnectorTestFixtures>({});
+const test = base.extend<RegologyDataConnectorTestFixtures>({
+  dataConnectorAdminPage: async ({ sysAdminPage }, use) => await use(new DataConnectorAdminPage(sysAdminPage)),
+  editRegologyConnectorPage: async ({ sysAdminPage }, use) => await use(new EditRegologyConnectorPage(sysAdminPage)),
+});
 
 test.describe('regology data connector', () => {
-  test('Create a new Regology connector', async () => {
+  let connectorsToDelete: string[] = [];
+
+  test.afterEach(async ({ dataConnectorAdminPage }) => {
+    await dataConnectorAdminPage.deleteConnectors(connectorsToDelete);
+    connectorsToDelete = [];
+  });
+
+  test('Create a new Regology connector', async ({ dataConnectorAdminPage, editRegologyConnectorPage }) => {
     test.info().annotations.push({
       type: AnnotationType.TestId,
       description: 'Test-846',
     });
 
-    expect(true).toBeTruthy();
+    const connectorName = FakeDataFactory.createFakeConnectorName();
+    connectorsToDelete.push(connectorName);
+
+    await test.step('Navigate to the data connectors admin page', async () => {
+      await dataConnectorAdminPage.goto();
+    });
+
+    await test.step('Create the risk recon data connector', async () => {
+      await dataConnectorAdminPage.createConnector(connectorName, 'Risk Recon Data Connector');
+      await dataConnectorAdminPage.page.waitForURL(editRegologyConnectorPage.pathRegex);
+    });
+
+    await test.step('Verify the data connector was created successfully', async () => {
+      await expect(editRegologyConnectorPage.connectionTab.nameInput).toHaveValue(connectorName);
+    });
   });
 
   test('Create a copy of a Regology connector', async () => {

--- a/tests/dataConnector/riskRecon.spec.ts
+++ b/tests/dataConnector/riskRecon.spec.ts
@@ -45,21 +45,68 @@ test.describe('risk recon data connector', () => {
     });
   });
 
-  test('Create a copy of a Risk Recon connector', async () => {
+  test('Create a copy of a Risk Recon connector', async ({ dataConnectorAdminPage, editRiskReconConnectorPage }) => {
     test.info().annotations.push({
       type: AnnotationType.TestId,
       description: 'Test-389',
     });
 
-    expect(true).toBeTruthy();
+    const connectorToCopyName = FakeDataFactory.createFakeConnectorName();
+    const connectorCopyName = FakeDataFactory.createFakeConnectorName();
+    connectorsToDelete.push(connectorToCopyName, connectorCopyName);
+
+    await test.step('Navigate to the data connectors admin page', async () => {
+      await dataConnectorAdminPage.goto();
+    });
+
+    await test.step('Create the risk recon data connector to copy', async () => {
+      await dataConnectorAdminPage.createConnector(connectorToCopyName, 'Risk Recon Data Connector');
+      await dataConnectorAdminPage.page.waitForURL(editRiskReconConnectorPage.pathRegex);
+    });
+
+    await test.step('Navigate back to the data connectors admin page', async () => {
+      await dataConnectorAdminPage.goto();
+    });
+
+    await test.step('Create a copy of the risk recon data connector', async () => {
+      await dataConnectorAdminPage.copyConnector('Risk Recon Data Connector', connectorToCopyName, connectorCopyName);
+      await dataConnectorAdminPage.page.waitForURL(editRiskReconConnectorPage.pathRegex);
+    });
+
+    await test.step('Verify the data connector was created successfully', async () => {
+      await expect(editRiskReconConnectorPage.connectionTab.nameInput).toHaveValue(connectorCopyName);
+    });
   });
 
-  test('Delete a Risk Recon connector', async () => {
+  test('Delete a Risk Recon connector', async ({ dataConnectorAdminPage, editRiskReconConnectorPage }) => {
     test.info().annotations.push({
       type: AnnotationType.TestId,
       description: 'Test-390',
     });
 
-    expect(true).toBeTruthy();
+    const connectorName = FakeDataFactory.createFakeConnectorName();
+
+    await test.step('Navigate to the data connectors admin page', async () => {
+      await dataConnectorAdminPage.goto();
+    });
+
+    await test.step('Create the data connector to delete', async () => {
+      await dataConnectorAdminPage.createConnector(connectorName, 'Risk Recon Data Connector');
+      await dataConnectorAdminPage.page.waitForURL(editRiskReconConnectorPage.pathRegex);
+    });
+
+    await test.step('Navigate back to the data connectors admin page', async () => {
+      await dataConnectorAdminPage.goto();
+    });
+
+    await test.step('Delete the data connector', async () => {
+      await dataConnectorAdminPage.deleteConnector(connectorName);
+    });
+
+    await test.step('Verify the data connector has been deleted', async () => {
+      const connectorRow = dataConnectorAdminPage.connectorsGrid.getByRole('row', { name: connectorName });
+
+      await expect(connectorRow).toBeHidden();
+    });
   });
 });

--- a/tests/dataConnector/riskRecon.spec.ts
+++ b/tests/dataConnector/riskRecon.spec.ts
@@ -1,0 +1,65 @@
+import { FakeDataFactory } from '../../factories/fakeDataFactory';
+import { test as base, expect } from '../../fixtures';
+import { DataConnectorAdminPage } from '../../pageObjectModels/dataConnectors/dataConnectorAdminPage';
+import { EditRiskReconConnectorPage } from '../../pageObjectModels/dataConnectors/editRiskReconConnectorPage';
+import { AnnotationType } from '../annotations';
+
+type RiskReconDataConnectorTestFixtures = {
+  dataConnectorAdminPage: DataConnectorAdminPage;
+  editRiskReconConnectorPage: EditRiskReconConnectorPage;
+};
+
+const test = base.extend<RiskReconDataConnectorTestFixtures>({
+  dataConnectorAdminPage: async ({ sysAdminPage }, use) => await use(new DataConnectorAdminPage(sysAdminPage)),
+  editRiskReconConnectorPage: async ({ sysAdminPage }, use) => await use(new EditRiskReconConnectorPage(sysAdminPage)),
+});
+
+test.describe('risk recon data connector', () => {
+  let connectorsToDelete: string[] = [];
+
+  test.afterEach(async ({ dataConnectorAdminPage }) => {
+    await dataConnectorAdminPage.deleteConnectors(connectorsToDelete);
+    connectorsToDelete = [];
+  });
+
+  test('Create a new Risk Recon connector', async ({ dataConnectorAdminPage, editRiskReconConnectorPage }) => {
+    test.info().annotations.push({
+      type: AnnotationType.TestId,
+      description: 'Test-388',
+    });
+
+    const connectorName = FakeDataFactory.createFakeConnectorName();
+    connectorsToDelete.push(connectorName);
+
+    await test.step('Navigate to the data connectors admin page', async () => {
+      await dataConnectorAdminPage.goto();
+    });
+
+    await test.step('Create the risk recon data connector', async () => {
+      await dataConnectorAdminPage.createConnector(connectorName, 'Risk Recon Data Connector');
+      await dataConnectorAdminPage.page.waitForURL(editRiskReconConnectorPage.pathRegex);
+    });
+
+    await test.step('Verify the data connector was created successfully', async () => {
+      await expect(editRiskReconConnectorPage.connectionTab.nameInput).toHaveValue(connectorName);
+    });
+  });
+
+  test('Create a copy of a Risk Recon connector', async () => {
+    test.info().annotations.push({
+      type: AnnotationType.TestId,
+      description: 'Test-389',
+    });
+
+    expect(true).toBeTruthy();
+  });
+
+  test('Delete a Risk Recon connector', async () => {
+    test.info().annotations.push({
+      type: AnnotationType.TestId,
+      description: 'Test-390',
+    });
+
+    expect(true).toBeTruthy();
+  });
+});

--- a/tests/dataConnector/securityScorecard.spec.ts
+++ b/tests/dataConnector/securityScorecard.spec.ts
@@ -89,12 +89,38 @@ test.describe('security scorecard data connector', () => {
     });
   });
 
-  test('Delete a Security Scorecard connector', async ({}) => {
+  test('Delete a Security Scorecard connector', async ({
+    dataConnectorAdminPage,
+    editSecurityScorecardConnectorPage,
+  }) => {
     test.info().annotations.push({
       type: AnnotationType.TestId,
       description: 'Test-411',
     });
 
-    expect(true).toBeTruthy();
+    const connectorName = FakeDataFactory.createFakeConnectorName();
+
+    await test.step('Navigate to the data connectors admin page', async () => {
+      await dataConnectorAdminPage.goto();
+    });
+
+    await test.step('Create the data connector to delete', async () => {
+      await dataConnectorAdminPage.createConnector(connectorName, 'Security Scorecard Data Connector');
+      await dataConnectorAdminPage.page.waitForURL(editSecurityScorecardConnectorPage.pathRegex);
+    });
+
+    await test.step('Navigate back to the data connectors admin page', async () => {
+      await dataConnectorAdminPage.goto();
+    });
+
+    await test.step('Delete the data connector', async () => {
+      await dataConnectorAdminPage.deleteConnector(connectorName);
+    });
+
+    await test.step('Verify the data connector has been deleted', async () => {
+      const connectorRow = dataConnectorAdminPage.connectorsGrid.getByRole('row', { name: connectorName });
+
+      await expect(connectorRow).toBeHidden();
+    });
   });
 });

--- a/tests/dataConnector/securityScorecard.spec.ts
+++ b/tests/dataConnector/securityScorecard.spec.ts
@@ -1,0 +1,35 @@
+import { test as base, expect } from '../../fixtures';
+import { AnnotationType } from '../annotations';
+
+type SecurityScorecardDataConnectorTestFixtures = {};
+
+const test = base.extend<SecurityScorecardDataConnectorTestFixtures>({});
+
+test.describe('security scorecard data connector', () => {
+  test('Create a new Security Scorecard connector', async ({}) => {
+    test.info().annotations.push({
+      type: AnnotationType.TestId,
+      description: 'Test-409',
+    });
+
+    expect(true).toBeTruthy();
+  });
+
+  test('Create a copy of a Security Scorecard connector', async ({}) => {
+    test.info().annotations.push({
+      type: AnnotationType.TestId,
+      description: 'Test-410',
+    });
+
+    expect(true).toBeTruthy();
+  });
+
+  test('Delete a Security Scorecard connector', async ({}) => {
+    test.info().annotations.push({
+      type: AnnotationType.TestId,
+      description: 'Test-411',
+    });
+
+    expect(true).toBeTruthy();
+  });
+});

--- a/tests/dataConnector/securityScorecard.spec.ts
+++ b/tests/dataConnector/securityScorecard.spec.ts
@@ -39,7 +39,7 @@ test.describe('security scorecard data connector', () => {
       await dataConnectorAdminPage.goto();
     });
 
-    await test.step('Create the Security Scorecard data connector', async () => {
+    await test.step('Create the security scorecard data connector', async () => {
       await dataConnectorAdminPage.createConnector(connectorName, 'Security Scorecard Data Connector');
       await dataConnectorAdminPage.page.waitForURL(editSecurityScorecardConnectorPage.pathRegex);
     });
@@ -49,13 +49,44 @@ test.describe('security scorecard data connector', () => {
     });
   });
 
-  test('Create a copy of a Security Scorecard connector', async ({}) => {
+  test('Create a copy of a Security Scorecard connector', async ({
+    dataConnectorAdminPage,
+    editSecurityScorecardConnectorPage,
+  }) => {
     test.info().annotations.push({
       type: AnnotationType.TestId,
       description: 'Test-410',
     });
 
-    expect(true).toBeTruthy();
+    const connectorToCopyName = FakeDataFactory.createFakeConnectorName();
+    const connectorCopyName = FakeDataFactory.createFakeConnectorName();
+    connectorsToDelete.push(connectorToCopyName, connectorCopyName);
+
+    await test.step('Navigate to the data connectors admin page', async () => {
+      await dataConnectorAdminPage.goto();
+    });
+
+    await test.step('Create the security scorecard data connector to copy', async () => {
+      await dataConnectorAdminPage.createConnector(connectorToCopyName, 'Security Scorecard Data Connector');
+      await dataConnectorAdminPage.page.waitForURL(editSecurityScorecardConnectorPage.pathRegex);
+    });
+
+    await test.step('Navigate back to the data connectors admin page', async () => {
+      await dataConnectorAdminPage.goto();
+    });
+
+    await test.step('Create a copy of the security scorecard data connector', async () => {
+      await dataConnectorAdminPage.copyConnector(
+        'Security Scorecard Data Connector',
+        connectorToCopyName,
+        connectorCopyName
+      );
+      await dataConnectorAdminPage.page.waitForURL(editSecurityScorecardConnectorPage.pathRegex);
+    });
+
+    await test.step('Verify the data connector was created successfully', async () => {
+      await expect(editSecurityScorecardConnectorPage.connectionTab.nameInput).toHaveValue(connectorCopyName);
+    });
   });
 
   test('Delete a Security Scorecard connector', async ({}) => {

--- a/tests/dataConnector/securityScorecard.spec.ts
+++ b/tests/dataConnector/securityScorecard.spec.ts
@@ -1,18 +1,52 @@
+import { FakeDataFactory } from '../../factories/fakeDataFactory';
 import { test as base, expect } from '../../fixtures';
+import { DataConnectorAdminPage } from '../../pageObjectModels/dataConnectors/dataConnectorAdminPage';
+import { EditSecurityScorecardConnectorPage } from '../../pageObjectModels/dataConnectors/editSecurityScorecardConnectorPage';
 import { AnnotationType } from '../annotations';
 
-type SecurityScorecardDataConnectorTestFixtures = {};
+type SecurityScorecardDataConnectorTestFixtures = {
+  dataConnectorAdminPage: DataConnectorAdminPage;
+  editSecurityScorecardConnectorPage: EditSecurityScorecardConnectorPage;
+};
 
-const test = base.extend<SecurityScorecardDataConnectorTestFixtures>({});
+const test = base.extend<SecurityScorecardDataConnectorTestFixtures>({
+  dataConnectorAdminPage: async ({ sysAdminPage }, use) => await use(new DataConnectorAdminPage(sysAdminPage)),
+  editSecurityScorecardConnectorPage: async ({ sysAdminPage }, use) =>
+    await use(new EditSecurityScorecardConnectorPage(sysAdminPage)),
+});
 
 test.describe('security scorecard data connector', () => {
-  test('Create a new Security Scorecard connector', async ({}) => {
+  let connectorsToDelete: string[] = [];
+
+  test.afterEach(async ({ dataConnectorAdminPage }) => {
+    await dataConnectorAdminPage.deleteConnectors(connectorsToDelete);
+    connectorsToDelete = [];
+  });
+
+  test('Create a new Security Scorecard connector', async ({
+    dataConnectorAdminPage,
+    editSecurityScorecardConnectorPage,
+  }) => {
     test.info().annotations.push({
       type: AnnotationType.TestId,
       description: 'Test-409',
     });
 
-    expect(true).toBeTruthy();
+    const connectorName = FakeDataFactory.createFakeConnectorName();
+    connectorsToDelete.push(connectorName);
+
+    await test.step('Navigate to the data connectors admin page', async () => {
+      await dataConnectorAdminPage.goto();
+    });
+
+    await test.step('Create the Security Scorecard data connector', async () => {
+      await dataConnectorAdminPage.createConnector(connectorName, 'Security Scorecard Data Connector');
+      await dataConnectorAdminPage.page.waitForURL(editSecurityScorecardConnectorPage.pathRegex);
+    });
+
+    await test.step('Verify the data connector was created successfully', async () => {
+      await expect(editSecurityScorecardConnectorPage.connectionTab.nameInput).toHaveValue(connectorName);
+    });
   });
 
   test('Create a copy of a Security Scorecard connector', async ({}) => {

--- a/tests/dataConnector/slack.spec.ts
+++ b/tests/dataConnector/slack.spec.ts
@@ -9,7 +9,10 @@ type SlackAppDataConnectorTestFixtures = {
   editSlackConnectorPage: EditSlackConnectorPage;
 };
 
-const test = base.extend<SlackAppDataConnectorTestFixtures>({});
+const test = base.extend<SlackAppDataConnectorTestFixtures>({
+  dataConnectorAdminPage: async ({ sysAdminPage }, use) => await use(new DataConnectorAdminPage(sysAdminPage)),
+  editSlackConnectorPage: async ({ sysAdminPage }, use) => await use(new EditSlackConnectorPage(sysAdminPage)),
+});
 
 test.describe('slack app data connector', () => {
   let connectorsToDelete: string[] = [];
@@ -32,8 +35,8 @@ test.describe('slack app data connector', () => {
       await dataConnectorAdminPage.goto();
     });
 
-    await test.step('Create the UCF data connector', async () => {
-      await dataConnectorAdminPage.createConnector(connectorName, 'Unified Compliance Framework (UCF) Connector');
+    await test.step('Create the slack app data connector', async () => {
+      await dataConnectorAdminPage.createConnector(connectorName, 'Slack App Connector');
       await dataConnectorAdminPage.page.waitForURL(editSlackConnectorPage.pathRegex);
     });
 
@@ -42,13 +45,37 @@ test.describe('slack app data connector', () => {
     });
   });
 
-  test('Create a copy of a Slack app connector', async () => {
+  test('Create a copy of a Slack app connector', async ({ dataConnectorAdminPage, editSlackConnectorPage }) => {
     test.info().annotations.push({
       type: AnnotationType.TestId,
       description: 'Test-438',
     });
 
-    expect(true).toBeTruthy();
+    const connectorToCopyName = FakeDataFactory.createFakeConnectorName();
+    const connectorCopyName = FakeDataFactory.createFakeConnectorName();
+    connectorsToDelete.push(connectorToCopyName, connectorCopyName);
+
+    await test.step('Navigate to the data connectors admin page', async () => {
+      await dataConnectorAdminPage.goto();
+    });
+
+    await test.step('Create the slack app data connector to copy', async () => {
+      await dataConnectorAdminPage.createConnector(connectorToCopyName, 'Slack App Connector');
+      await dataConnectorAdminPage.page.waitForURL(editSlackConnectorPage.pathRegex);
+    });
+
+    await test.step('Navigate back to the data connectors admin page', async () => {
+      await dataConnectorAdminPage.goto();
+    });
+
+    await test.step('Create a copy of the slack app data connector', async () => {
+      await dataConnectorAdminPage.copyConnector('Slack App Connector', connectorToCopyName, connectorCopyName);
+      await dataConnectorAdminPage.page.waitForURL(editSlackConnectorPage.pathRegex);
+    });
+
+    await test.step('Verify the data connector was created successfully', async () => {
+      await expect(editSlackConnectorPage.generalTab.nameInput).toHaveValue(connectorCopyName);
+    });
   });
 
   test('Delete a Slack app connector', async () => {

--- a/tests/dataConnector/slack.spec.ts
+++ b/tests/dataConnector/slack.spec.ts
@@ -1,0 +1,35 @@
+import { test as base, expect } from '../../fixtures';
+import { AnnotationType } from '../annotations';
+
+type SlackAppDataConnectorTestFixtures = {};
+
+const test = base.extend<SlackAppDataConnectorTestFixtures>({});
+
+test.describe('slack app data connector', () => {
+  test('Create a new Slack app connector', async () => {
+    test.info().annotations.push({
+      type: AnnotationType.TestId,
+      description: 'Test-437',
+    });
+
+    expect(true).toBeTruthy();
+  });
+
+  test('Create a copy of a Slack app connector', async () => {
+    test.info().annotations.push({
+      type: AnnotationType.TestId,
+      description: 'Test-438',
+    });
+
+    expect(true).toBeTruthy();
+  });
+
+  test('Delete a Slack app connector', async () => {
+    test.info().annotations.push({
+      type: AnnotationType.TestId,
+      description: 'Test-439',
+    });
+
+    expect(true).toBeTruthy();
+  });
+});

--- a/tests/dataConnector/slack.spec.ts
+++ b/tests/dataConnector/slack.spec.ts
@@ -1,18 +1,45 @@
+import { FakeDataFactory } from '../../factories/fakeDataFactory';
 import { test as base, expect } from '../../fixtures';
+import { DataConnectorAdminPage } from '../../pageObjectModels/dataConnectors/dataConnectorAdminPage';
+import { EditSlackConnectorPage } from '../../pageObjectModels/dataConnectors/editSlackConnectorPage';
 import { AnnotationType } from '../annotations';
 
-type SlackAppDataConnectorTestFixtures = {};
+type SlackAppDataConnectorTestFixtures = {
+  dataConnectorAdminPage: DataConnectorAdminPage;
+  editSlackConnectorPage: EditSlackConnectorPage;
+};
 
 const test = base.extend<SlackAppDataConnectorTestFixtures>({});
 
 test.describe('slack app data connector', () => {
-  test('Create a new Slack app connector', async () => {
+  let connectorsToDelete: string[] = [];
+
+  test.afterEach(async ({ dataConnectorAdminPage }) => {
+    await dataConnectorAdminPage.deleteConnectors(connectorsToDelete);
+    connectorsToDelete = [];
+  });
+
+  test('Create a new Slack app connector', async ({ dataConnectorAdminPage, editSlackConnectorPage }) => {
     test.info().annotations.push({
       type: AnnotationType.TestId,
       description: 'Test-437',
     });
 
-    expect(true).toBeTruthy();
+    const connectorName = FakeDataFactory.createFakeConnectorName();
+    connectorsToDelete.push(connectorName);
+
+    await test.step('Navigate to the data connectors admin page', async () => {
+      await dataConnectorAdminPage.goto();
+    });
+
+    await test.step('Create the UCF data connector', async () => {
+      await dataConnectorAdminPage.createConnector(connectorName, 'Unified Compliance Framework (UCF) Connector');
+      await dataConnectorAdminPage.page.waitForURL(editSlackConnectorPage.pathRegex);
+    });
+
+    await test.step('Verify the data connector was created successfully', async () => {
+      await expect(editSlackConnectorPage.generalTab.nameInput).toHaveValue(connectorName);
+    });
   });
 
   test('Create a copy of a Slack app connector', async () => {

--- a/tests/dataConnector/slack.spec.ts
+++ b/tests/dataConnector/slack.spec.ts
@@ -78,12 +78,35 @@ test.describe('slack app data connector', () => {
     });
   });
 
-  test('Delete a Slack app connector', async () => {
+  test('Delete a Slack app connector', async ({ dataConnectorAdminPage, editSlackConnectorPage }) => {
     test.info().annotations.push({
       type: AnnotationType.TestId,
       description: 'Test-439',
     });
 
-    expect(true).toBeTruthy();
+    const connectorName = FakeDataFactory.createFakeConnectorName();
+
+    await test.step('Navigate to the data connectors admin page', async () => {
+      await dataConnectorAdminPage.goto();
+    });
+
+    await test.step('Create the data connector to delete', async () => {
+      await dataConnectorAdminPage.createConnector(connectorName, 'Slack App Connector');
+      await dataConnectorAdminPage.page.waitForURL(editSlackConnectorPage.pathRegex);
+    });
+
+    await test.step('Navigate back to the data connectors admin page', async () => {
+      await dataConnectorAdminPage.goto();
+    });
+
+    await test.step('Delete the data connector', async () => {
+      await dataConnectorAdminPage.deleteConnector(connectorName);
+    });
+
+    await test.step('Verify the data connector has been deleted', async () => {
+      const connectorRow = dataConnectorAdminPage.connectorsGrid.getByRole('row', { name: connectorName });
+
+      await expect(connectorRow).toBeHidden();
+    });
   });
 });

--- a/tests/dataConnector/ucf.spec.ts
+++ b/tests/dataConnector/ucf.spec.ts
@@ -82,12 +82,35 @@ test.describe('ucf data connector', () => {
     });
   });
 
-  test('Delete a UCF connector', async () => {
+  test('Delete a UCF connector', async ({ dataConnectorAdminPage, editUcfConnectorPage }) => {
     test.info().annotations.push({
       type: AnnotationType.TestId,
       description: 'Test-425',
     });
 
-    expect(true).toBeTruthy();
+    const connectorName = FakeDataFactory.createFakeConnectorName();
+
+    await test.step('Navigate to the data connectors admin page', async () => {
+      await dataConnectorAdminPage.goto();
+    });
+
+    await test.step('Create the data connector to delete', async () => {
+      await dataConnectorAdminPage.createConnector(connectorName, 'Unified Compliance Framework (UCF) Connector');
+      await dataConnectorAdminPage.page.waitForURL(editUcfConnectorPage.pathRegex);
+    });
+
+    await test.step('Navigate back to the data connectors admin page', async () => {
+      await dataConnectorAdminPage.goto();
+    });
+
+    await test.step('Delete the data connector', async () => {
+      await dataConnectorAdminPage.deleteConnector(connectorName);
+    });
+
+    await test.step('Verify the data connector has been deleted', async () => {
+      const connectorRow = dataConnectorAdminPage.connectorsGrid.getByRole('row', { name: connectorName });
+
+      await expect(connectorRow).toBeHidden();
+    });
   });
 });

--- a/tests/dataConnector/ucf.spec.ts
+++ b/tests/dataConnector/ucf.spec.ts
@@ -45,13 +45,41 @@ test.describe('ucf data connector', () => {
     });
   });
 
-  test('Create a copy of a UCF connector', async () => {
+  test('Create a copy of a UCF connector', async ({ dataConnectorAdminPage, editUcfConnectorPage }) => {
     test.info().annotations.push({
       type: AnnotationType.TestId,
       description: 'Test-424',
     });
 
-    expect(true).toBeTruthy();
+    const connectorToCopyName = FakeDataFactory.createFakeConnectorName();
+    const connectorCopyName = FakeDataFactory.createFakeConnectorName();
+    connectorsToDelete.push(connectorToCopyName, connectorCopyName);
+
+    await test.step('Navigate to the data connectors admin page', async () => {
+      await dataConnectorAdminPage.goto();
+    });
+
+    await test.step('Create the UCF data connector to copy', async () => {
+      await dataConnectorAdminPage.createConnector(connectorToCopyName, 'Unified Compliance Framework (UCF) Connector');
+      await dataConnectorAdminPage.page.waitForURL(editUcfConnectorPage.pathRegex);
+    });
+
+    await test.step('Navigate back to the data connectors admin page', async () => {
+      await dataConnectorAdminPage.goto();
+    });
+
+    await test.step('Create a copy of the UCF data connector', async () => {
+      await dataConnectorAdminPage.copyConnector(
+        'Unified Compliance Framework (UCF) Connector',
+        connectorToCopyName,
+        connectorCopyName
+      );
+      await dataConnectorAdminPage.page.waitForURL(editUcfConnectorPage.pathRegex);
+    });
+
+    await test.step('Verify the data connector was created successfully', async () => {
+      await expect(editUcfConnectorPage.connectionTab.nameInput).toHaveValue(connectorCopyName);
+    });
   });
 
   test('Delete a UCF connector', async () => {

--- a/tests/dataConnector/ucf.spec.ts
+++ b/tests/dataConnector/ucf.spec.ts
@@ -1,18 +1,48 @@
+import { FakeDataFactory } from '../../factories/fakeDataFactory';
 import { test as base, expect } from '../../fixtures';
+import { DataConnectorAdminPage } from '../../pageObjectModels/dataConnectors/dataConnectorAdminPage';
+import { EditUcfConnectorPage } from '../../pageObjectModels/dataConnectors/editUcfConnectorPage';
 import { AnnotationType } from '../annotations';
 
-type UCFDataConnectorTestFixtures = {};
+type UCFDataConnectorTestFixtures = {
+  dataConnectorAdminPage: DataConnectorAdminPage;
+  editUcfConnectorPage: EditUcfConnectorPage;
+};
 
-const test = base.extend<UCFDataConnectorTestFixtures>({});
+const test = base.extend<UCFDataConnectorTestFixtures>({
+  dataConnectorAdminPage: async ({ sysAdminPage }, use) => await use(new DataConnectorAdminPage(sysAdminPage)),
+  editUcfConnectorPage: async ({ sysAdminPage }, use) => await use(new EditUcfConnectorPage(sysAdminPage)),
+});
 
 test.describe('ucf data connector', () => {
-  test('Create a new UCF connector', async () => {
+  let connectorsToDelete: string[] = [];
+
+  test.afterEach(async ({ dataConnectorAdminPage }) => {
+    await dataConnectorAdminPage.deleteConnectors(connectorsToDelete);
+    connectorsToDelete = [];
+  });
+
+  test('Create a new UCF connector', async ({ dataConnectorAdminPage, editUcfConnectorPage }) => {
     test.info().annotations.push({
       type: AnnotationType.TestId,
       description: 'Test-423',
     });
 
-    expect(true).toBeTruthy();
+    const connectorName = FakeDataFactory.createFakeConnectorName();
+    connectorsToDelete.push(connectorName);
+
+    await test.step('Navigate to the data connectors admin page', async () => {
+      await dataConnectorAdminPage.goto();
+    });
+
+    await test.step('Create the UCF data connector', async () => {
+      await dataConnectorAdminPage.createConnector(connectorName, 'Unified Compliance Framework (UCF) Connector');
+      await dataConnectorAdminPage.page.waitForURL(editUcfConnectorPage.pathRegex);
+    });
+
+    await test.step('Verify the data connector was created successfully', async () => {
+      await expect(editUcfConnectorPage.connectionTab.nameInput).toHaveValue(connectorName);
+    });
   });
 
   test('Create a copy of a UCF connector', async () => {

--- a/tests/dataConnector/ucf.spec.ts
+++ b/tests/dataConnector/ucf.spec.ts
@@ -1,0 +1,35 @@
+import { test as base, expect } from '../../fixtures';
+import { AnnotationType } from '../annotations';
+
+type UCFDataConnectorTestFixtures = {};
+
+const test = base.extend<UCFDataConnectorTestFixtures>({});
+
+test.describe('ucf data connector', () => {
+  test('Create a new UCF connector', async () => {
+    test.info().annotations.push({
+      type: AnnotationType.TestId,
+      description: 'Test-423',
+    });
+
+    expect(true).toBeTruthy();
+  });
+
+  test('Create a copy of a UCF connector', async () => {
+    test.info().annotations.push({
+      type: AnnotationType.TestId,
+      description: 'Test-424',
+    });
+
+    expect(true).toBeTruthy();
+  });
+
+  test('Delete a UCF connector', async () => {
+    test.info().annotations.push({
+      type: AnnotationType.TestId,
+      description: 'Test-425',
+    });
+
+    expect(true).toBeTruthy();
+  });
+});


### PR DESCRIPTION
closes #150

- **chore: stub out ucf tests**
- **tests: add test for Test-423**
- **tests: add test for Test-424**
- **tests: add test for Test-425**
- **chore: stub out slack app connector tests**
- **tests: add test for Test-437**
- **tests: wip on slack connector tests**
- **tests: add test for Test-439:**
- **chore: stub out security scorecard tests**
- **tests: add test for Test-409**
- **tests: add test for Test-410**
- **tests: add test for Test-411**
- **tests: add test for Test-388**
- **tests: add test for Test-389 and Test-390**
- **chore: stub out regology tests**
- **tests: add test for Test-846**
- **tests: add test for Test-847 and Test-848**
- **tests: add test for Test-402**
- **tests: add test for Test-402**
- **tests: add test for Test-403 and Test-404**
- **tests: add test for Test-840, Test-841, and Test-842**
- **tests: add test for Test-416, Test-417, and Test-417**
