### PR TITLE
fix: address messaging alert icon causing flaky screenshot comparisons

### DIFF
--- a/models/report.ts
+++ b/models/report.ts
@@ -55,7 +55,7 @@ type ReportObject = {
 };
 
 export abstract class Report {
-  id?: number;
+  id: number;
   appName: string;
   displayType: ReportDisplayType;
   displayFields: DisplayField[];
@@ -67,6 +67,7 @@ export abstract class Report {
     displayFields = [],
     relatedData = [],
   }: ReportObject) {
+    this.id = 0;
     this.appName = appName;
     this.displayType = displayType;
     this.displayFields = displayFields;

--- a/package-lock.json
+++ b/package-lock.json
@@ -2244,9 +2244,9 @@
       }
     },
     "node_modules/mailparser": {
-      "version": "3.9.10",
-      "resolved": "https://registry.npmjs.org/mailparser/-/mailparser-3.9.10.tgz",
-      "integrity": "sha512-/PWScCewV4/97Y0wDNgQkcQ4FK8AK0aGVPAg51lVyisiRep9BkzkzT3/l/7aSkQ1k2T1iJu1tdXVF84wjGdDqw==",
+      "version": "3.9.11",
+      "resolved": "https://registry.npmjs.org/mailparser/-/mailparser-3.9.11.tgz",
+      "integrity": "sha512-N1LPZwp1yVblJQukv5NAedlkHeA+PmZYdPCfk0Uwohn8JFOM8fYoUGF978qwlQcd3AlUleuzK0fu/EFAHPM9tg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2257,7 +2257,7 @@
         "iconv-lite": "0.7.2",
         "libmime": "5.3.8",
         "linkify-it": "5.0.1",
-        "nodemailer": "9.0.0",
+        "nodemailer": "9.0.1",
         "punycode.js": "2.3.1",
         "tlds": "1.261.0"
       }
@@ -2375,9 +2375,9 @@
       }
     },
     "node_modules/nodemailer": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-9.0.0.tgz",
-      "integrity": "sha512-tbPTid7d/p9jAA8CRZ3iomvrMaST0o6NYuY7v6JQZHpPRZ61mLFSPKYd7342NtOFuej9/+L48SOIxwfu2uDvtw==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-9.0.1.tgz",
+      "integrity": "sha512-Gwv8SQewT616ZM/URn0H54b8PWo/Wum7md3EW2aWy1lO27+WZCX+Xyak3J+NlmHUjDh5ME+uesJUDRbR3Ye8Bw==",
       "dev": true,
       "license": "MIT-0",
       "engines": {

--- a/tests/keyMetrics/keyMetrics.spec.ts
+++ b/tests/keyMetrics/keyMetrics.spec.ts
@@ -1,10 +1,11 @@
-import { expect } from '@playwright/test';
 import { FieldType } from '../../componentObjectModels/menus/addFieldTypeMenu';
 import { FakeDataFactory } from '../../factories/fakeDataFactory';
-import { test as base } from '../../fixtures';
+import { test as base, expect, Page } from '../../fixtures';
 import { createApp } from '../../fixtures/app.fixtures';
+import { createTestUserPageFixture } from '../../fixtures/auth.fixtures';
 import { createContainerFixture } from '../../fixtures/container.fixtures';
 import { createDashboardFixture } from '../../fixtures/dashboard.fixtures';
+import { createUserFixture } from '../../fixtures/user.fixtures';
 import { App } from '../../models/app';
 import { Container } from '../../models/container';
 import { Dashboard } from '../../models/dashboard';
@@ -18,6 +19,7 @@ import {
 } from '../../models/keyMetric';
 import { SavedReportAsReportDataOnly } from '../../models/report';
 import { TextField } from '../../models/textField';
+import { User, UserStatus } from '../../models/user';
 import { AppAdminPage } from '../../pageObjectModels/apps/appAdminPage';
 import { AppsAdminPage } from '../../pageObjectModels/apps/appsAdminPage';
 import { DashboardPage } from '../../pageObjectModels/dashboards/dashboardPage';
@@ -30,10 +32,12 @@ import { AddContentPage } from './../../pageObjectModels/content/addContentPage'
 import { EditContentPage } from './../../pageObjectModels/content/editContentPage';
 
 type KeyMetricTestFixtures = {
-  dashboardsAdminPage: DashboardsAdminPage;
   sourceApp: App;
   container: Container;
   dashboard: Dashboard;
+  testUser: User;
+  testUserPage: Page;
+  dashboardsAdminPage: DashboardsAdminPage;
   dashboardPage: DashboardPage;
   addContentPage: AddContentPage;
   editContentPage: EditContentPage;
@@ -44,7 +48,6 @@ type KeyMetricTestFixtures = {
 };
 
 const test = base.extend<KeyMetricTestFixtures>({
-  dashboardsAdminPage: async ({ sysAdminPage }, use) => await use(new DashboardsAdminPage(sysAdminPage)),
   sourceApp: async ({ sysAdminPage }, use) => {
     const app = await createApp(sysAdminPage);
     await use(app);
@@ -58,6 +61,22 @@ const test = base.extend<KeyMetricTestFixtures>({
       },
       use
     ),
+  testUser: async ({ browser, sysAdminPage }, use, testInfo) => {
+    await createUserFixture(
+      {
+        browser,
+        sysAdminPage,
+        sysAdmin: true,
+        userStatus: UserStatus.Active,
+        roles: [],
+      },
+      use,
+      testInfo
+    );
+  },
+  testUserPage: async ({ browser, testUser }, use, testInfo) =>
+    await createTestUserPageFixture({ browser, user: testUser }, use, testInfo),
+  dashboardsAdminPage: async ({ testUserPage }, use) => await use(new DashboardsAdminPage(testUserPage)),
   dashboardPage: async ({ sysAdminPage }, use) => await use(new DashboardPage(sysAdminPage)),
   addContentPage: async ({ sysAdminPage }, use) => await use(new AddContentPage(sysAdminPage)),
   editContentPage: async ({ sysAdminPage }, use) => await use(new EditContentPage(sysAdminPage)),
@@ -373,7 +392,7 @@ test.describe('key metrics', () => {
   test(
     'Verify an app/survey single value key metric displays and functions as expected',
     { tag: [Tags.Snapshot] },
-    async ({ sourceApp, dashboardsAdminPage, dashboard, dashboardPage }) => {
+    async ({ sourceApp, dashboardsAdminPage, dashboard, dashboardPage, testUserPage }) => {
       test.info().annotations.push({
         type: AnnotationType.TestId,
         description: 'Test-779',
@@ -411,7 +430,7 @@ test.describe('key metrics', () => {
       });
 
       await test.step('Verify the key metric displays as expected', async () => {
-        const keyMetricCard = await getKeyMetricForScreenshot(dashboardPage, keyMetric);
+        const keyMetricCard = await getKeyMetricForScreenshot(testUserPage, dashboard, keyMetric);
         await expect(keyMetricCard).toHaveScreenshot();
       });
     }
@@ -428,6 +447,7 @@ test.describe('key metrics', () => {
       dashboardPage,
       addContentPage,
       editContentPage,
+      testUserPage,
     }) => {
       test.info().annotations.push({
         type: AnnotationType.TestId,
@@ -509,7 +529,7 @@ test.describe('key metrics', () => {
       });
 
       await test.step('Verify the key metric displays as expected', async () => {
-        const keyMetricCard = await getKeyMetricForScreenshot(dashboardPage, keyMetric);
+        const keyMetricCard = await getKeyMetricForScreenshot(testUserPage, dashboard, keyMetric);
         await expect(keyMetricCard).toHaveScreenshot();
       });
     }
@@ -522,6 +542,7 @@ test.describe('key metrics', () => {
     dashboardsAdminPage,
     dashboard,
     dashboardPage,
+    testUserPage,
   }) => {
     test.info().annotations.push({
       type: AnnotationType.TestId,
@@ -573,7 +594,7 @@ test.describe('key metrics', () => {
     });
 
     await test.step('Verify the key metric displays as expected', async () => {
-      const keyMetricCard = await getKeyMetricForScreenshot(dashboardPage, keyMetric);
+      const keyMetricCard = await getKeyMetricForScreenshot(testUserPage, dashboard, keyMetric);
       await expect(keyMetricCard).toHaveScreenshot();
     });
   });
@@ -791,7 +812,7 @@ test.describe('key metrics', () => {
   test(
     'Verify a bulb gauge key metric displays and functions as expected',
     { tag: [Tags.Snapshot] },
-    async ({ sourceApp, dashboardsAdminPage, dashboard, dashboardPage }) => {
+    async ({ sourceApp, dashboardsAdminPage, dashboard, dashboardPage, testUserPage }) => {
       test.info().annotations.push({
         type: AnnotationType.TestId,
         description: 'Test-799',
@@ -834,7 +855,7 @@ test.describe('key metrics', () => {
       });
 
       await test.step('Verify the key metric displays as expected', async () => {
-        const keyMetricCard = await getKeyMetricForScreenshot(dashboardPage, keyMetric);
+        const keyMetricCard = await getKeyMetricForScreenshot(testUserPage, dashboard, keyMetric);
         await expect(keyMetricCard).toHaveScreenshot();
       });
     }
@@ -843,7 +864,7 @@ test.describe('key metrics', () => {
   test(
     'Verify a bar gauge key metric displays and functions as expected',
     { tag: [Tags.Snapshot] },
-    async ({ sourceApp, dashboardsAdminPage, dashboard, dashboardPage }) => {
+    async ({ sourceApp, dashboardsAdminPage, dashboard, dashboardPage, testUserPage }) => {
       test.info().annotations.push({
         type: AnnotationType.TestId,
         description: 'Test-800',
@@ -893,7 +914,7 @@ test.describe('key metrics', () => {
       });
 
       await test.step('Verify the key metric displays as expected', async () => {
-        const keyMetricCard = await getKeyMetricForScreenshot(dashboardPage, keyMetric);
+        const keyMetricCard = await getKeyMetricForScreenshot(testUserPage, dashboard, keyMetric);
         await expect(keyMetricCard).toHaveScreenshot();
       });
     }
@@ -902,7 +923,15 @@ test.describe('key metrics', () => {
   test(
     'Verify a donut gauge key metric displays and functions as expected',
     { tag: [Tags.Snapshot] },
-    async ({ sourceApp, addContentPage, editContentPage, dashboardsAdminPage, dashboard, dashboardPage }) => {
+    async ({
+      sourceApp,
+      addContentPage,
+      editContentPage,
+      dashboardsAdminPage,
+      dashboard,
+      dashboardPage,
+      testUserPage,
+    }) => {
       test.info().annotations.push({
         type: AnnotationType.TestId,
         description: 'Test-801',
@@ -957,7 +986,7 @@ test.describe('key metrics', () => {
       });
 
       await test.step('Verify the key metric displays as expected', async () => {
-        const keyMetricCard = await getKeyMetricForScreenshot(dashboardPage, keyMetric);
+        const keyMetricCard = await getKeyMetricForScreenshot(testUserPage, dashboard, keyMetric);
         await expect(keyMetricCard).toHaveScreenshot();
       });
     }
@@ -966,7 +995,7 @@ test.describe('key metrics', () => {
   test(
     'Verify a dial gauge key metric displays and functions as expected',
     { tag: [Tags.Snapshot] },
-    async ({ sourceApp, dashboardsAdminPage, dashboard, dashboardPage }) => {
+    async ({ sourceApp, dashboardsAdminPage, dashboard, dashboardPage, testUserPage }) => {
       test.info().annotations.push({
         type: AnnotationType.TestId,
         description: 'Test-802',
@@ -1016,7 +1045,7 @@ test.describe('key metrics', () => {
       });
 
       await test.step('Verify the key metric displays as expected', async () => {
-        const keyMetricCard = await getKeyMetricForScreenshot(dashboardPage, keyMetric);
+        const keyMetricCard = await getKeyMetricForScreenshot(testUserPage, dashboard, keyMetric);
         await expect(keyMetricCard).toHaveScreenshot();
       });
     }
@@ -1024,10 +1053,14 @@ test.describe('key metrics', () => {
 });
 
 async function getKeyMetricForScreenshot(
-  dashboardPage: DashboardPage,
+  testUserPage: Page,
+  dashboard: Dashboard,
   keyMetric: KeyMetric,
   placeholderName: string = 'Key Metric'
 ) {
+  const dashboardPage = new DashboardPage(testUserPage);
+
+  await dashboardPage.goto(dashboard.id);
   const keyMetricCard = dashboardPage.getDashboardItem(keyMetric.objectName);
   const keyMetricTitle = keyMetricCard.locator('.title');
 

--- a/tests/report/report.spec.ts
+++ b/tests/report/report.spec.ts
@@ -1,7 +1,9 @@
 import { FieldType } from '../../componentObjectModels/menus/addFieldTypeMenu';
 import { FakeDataFactory } from '../../factories/fakeDataFactory';
-import { test as base, expect, Route } from '../../fixtures';
+import { test as base, expect, Page, Route } from '../../fixtures';
 import { app, createApp } from '../../fixtures/app.fixtures';
+import { createTestUserPageFixture } from '../../fixtures/auth.fixtures';
+import { createUserFixture } from '../../fixtures/user.fixtures';
 import { App } from '../../models/app';
 import {
   BarChart,
@@ -27,6 +29,7 @@ import { ListValue } from '../../models/listValue';
 import { ReferenceField } from '../../models/referenceField';
 import {
   DisplayField,
+  Report,
   ReportSchedule,
   SavedReportAsCalendar,
   SavedReportAsChart,
@@ -35,6 +38,7 @@ import {
   SavedReportAsReportDataOnly,
 } from '../../models/report';
 import { TextField } from '../../models/textField';
+import { User, UserStatus } from '../../models/user';
 import { AppAdminPage } from '../../pageObjectModels/apps/appAdminPage';
 import { AppsAdminPage } from '../../pageObjectModels/apps/appsAdminPage';
 import { AddContentPage } from '../../pageObjectModels/content/addContentPage';
@@ -49,6 +53,8 @@ import { Tags } from '../tags';
 type ReportTestFixtures = {
   referencedApp: App;
   sourceApp: App;
+  testUser: User;
+  testUserPage: Page;
   reportHomePage: ReportHomePage;
   reportAppPage: ReportAppPage;
   reportPage: ReportPage;
@@ -61,6 +67,21 @@ type ReportTestFixtures = {
 const test = base.extend<ReportTestFixtures>({
   referencedApp: app,
   sourceApp: app,
+  testUser: async ({ browser, sysAdminPage }, use, testInfo) => {
+    await createUserFixture(
+      {
+        browser,
+        sysAdminPage,
+        sysAdmin: true,
+        userStatus: UserStatus.Active,
+        roles: [],
+      },
+      use,
+      testInfo
+    );
+  },
+  testUserPage: async ({ browser, testUser }, use, testInfo) =>
+    await createTestUserPageFixture({ browser, user: testUser }, use, testInfo),
   reportHomePage: async ({ sysAdminPage }, use) => await use(new ReportHomePage(sysAdminPage)),
   reportAppPage: async ({ sysAdminPage }, use) => await use(new ReportAppPage(sysAdminPage)),
   reportPage: async ({ sysAdminPage }, use) => await use(new ReportPage(sysAdminPage)),
@@ -829,7 +850,7 @@ test.describe('report', () => {
     {
       tag: [Tags.Snapshot],
     },
-    async ({ appAdminPage, sourceApp, addContentPage, editContentPage, reportAppPage, reportPage }) => {
+    async ({ appAdminPage, sourceApp, addContentPage, editContentPage, reportAppPage, reportPage, testUserPage }) => {
       test.info().annotations.push({
         type: AnnotationType.TestId,
         description: 'Test-608',
@@ -850,6 +871,7 @@ test.describe('report', () => {
           visibility: 'Display Chart Only',
           groupData: fields.groupField.name,
         }),
+        security: 'Public',
       });
 
       await test.step("Navigate to the app's reports home page", async () => {
@@ -860,10 +882,14 @@ test.describe('report', () => {
         await reportAppPage.createReport(report);
         await reportAppPage.page.waitForURL(reportPage.pathRegex);
         await reportPage.waitUntilLoaded();
+
+        report.id = reportPage.getReportIdFromUrl();
+        expect(report.id).not.toBe(0);
       });
 
       await test.step('Verify the bar chart displays as expected', async () => {
-        await expect(reportPage.reportContents).toHaveScreenshot();
+        const reportContents = await getReportContentsForScreenshot({ testUserPage, report });
+        await expect(reportContents).toHaveScreenshot();
       });
     }
   );
@@ -873,7 +899,7 @@ test.describe('report', () => {
     {
       tag: [Tags.Snapshot],
     },
-    async ({ appAdminPage, sourceApp, addContentPage, editContentPage, reportAppPage, reportPage }) => {
+    async ({ appAdminPage, sourceApp, addContentPage, editContentPage, reportAppPage, reportPage, testUserPage }) => {
       test.info().annotations.push({
         type: AnnotationType.TestId,
         description: 'Test-609',
@@ -894,6 +920,7 @@ test.describe('report', () => {
           visibility: 'Display Chart Only',
           groupData: fields.groupField.name,
         }),
+        security: 'Public',
       });
 
       await test.step("Navigate to the app's reports home page", async () => {
@@ -904,10 +931,14 @@ test.describe('report', () => {
         await reportAppPage.createReport(report);
         await reportAppPage.page.waitForURL(reportPage.pathRegex);
         await reportPage.waitUntilLoaded();
+
+        report.id = reportPage.getReportIdFromUrl();
+        expect(report.id).not.toBe(0);
       });
 
       await test.step('Verify the column chart displays as expected', async () => {
-        await expect(reportPage.reportContents).toHaveScreenshot();
+        const reportContents = await getReportContentsForScreenshot({ testUserPage, report });
+        await expect(reportContents).toHaveScreenshot();
       });
     }
   );
@@ -917,7 +948,7 @@ test.describe('report', () => {
     {
       tag: [Tags.Snapshot],
     },
-    async ({ appAdminPage, sourceApp, addContentPage, editContentPage, reportAppPage, reportPage }) => {
+    async ({ appAdminPage, sourceApp, addContentPage, editContentPage, reportAppPage, reportPage, testUserPage }) => {
       test.info().annotations.push({
         type: AnnotationType.TestId,
         description: 'Test-610',
@@ -938,6 +969,7 @@ test.describe('report', () => {
           visibility: 'Display Chart Only',
           groupData: fields.groupField.name,
         }),
+        security: 'Public',
       });
 
       await test.step("Navigate to the app's reports home page", async () => {
@@ -948,10 +980,14 @@ test.describe('report', () => {
         await reportAppPage.createReport(report);
         await reportAppPage.page.waitForURL(reportPage.pathRegex);
         await reportPage.waitUntilLoaded();
+
+        report.id = reportPage.getReportIdFromUrl();
+        expect(report.id).not.toBe(0);
       });
 
       await test.step('Verify the pie chart displays as expected', async () => {
-        await expect(reportPage.reportContents).toHaveScreenshot();
+        const reportContents = await getReportContentsForScreenshot({ testUserPage, report });
+        await expect(reportContents).toHaveScreenshot();
       });
     }
   );
@@ -961,7 +997,7 @@ test.describe('report', () => {
     {
       tag: [Tags.Snapshot],
     },
-    async ({ appAdminPage, sourceApp, addContentPage, editContentPage, reportAppPage, reportPage }) => {
+    async ({ appAdminPage, sourceApp, addContentPage, editContentPage, reportAppPage, reportPage, testUserPage }) => {
       test.info().annotations.push({
         type: AnnotationType.TestId,
         description: 'Test-611',
@@ -982,6 +1018,7 @@ test.describe('report', () => {
           visibility: 'Display Chart Only',
           groupData: fields.groupField.name,
         }),
+        security: 'Public',
       });
 
       await test.step("Navigate to the app's reports home page", async () => {
@@ -992,10 +1029,14 @@ test.describe('report', () => {
         await reportAppPage.createReport(report);
         await reportAppPage.page.waitForURL(reportPage.pathRegex);
         await reportPage.waitUntilLoaded();
+
+        report.id = reportPage.getReportIdFromUrl();
+        expect(report.id).not.toBe(0);
       });
 
       await test.step('Verify the donut chart displays as expected', async () => {
-        await expect(reportPage.reportContents).toHaveScreenshot();
+        const reportContents = await getReportContentsForScreenshot({ testUserPage, report });
+        await expect(reportContents).toHaveScreenshot();
       });
     }
   );
@@ -1005,7 +1046,7 @@ test.describe('report', () => {
     {
       tag: [Tags.Snapshot],
     },
-    async ({ appAdminPage, sourceApp, addContentPage, editContentPage, reportAppPage, reportPage }) => {
+    async ({ appAdminPage, sourceApp, addContentPage, editContentPage, reportAppPage, reportPage, testUserPage }) => {
       test.info().annotations.push({
         type: AnnotationType.TestId,
         description: 'Test-612',
@@ -1026,6 +1067,7 @@ test.describe('report', () => {
           visibility: 'Display Chart Only',
           groupData: fields.groupField.name,
         }),
+        security: 'Public',
       });
 
       await test.step("Navigate to the app's reports home page", async () => {
@@ -1036,10 +1078,14 @@ test.describe('report', () => {
         await reportAppPage.createReport(report);
         await reportAppPage.page.waitForURL(reportPage.pathRegex);
         await reportPage.waitUntilLoaded();
+
+        report.id = reportPage.getReportIdFromUrl();
+        expect(report.id).not.toBe(0);
       });
 
       await test.step('Verify the line chart displays as expected', async () => {
-        await expect(reportPage.reportContents).toHaveScreenshot();
+        const reportContents = await getReportContentsForScreenshot({ testUserPage, report });
+        await expect(reportContents).toHaveScreenshot();
       });
     }
   );
@@ -1049,7 +1095,7 @@ test.describe('report', () => {
     {
       tag: [Tags.Snapshot],
     },
-    async ({ appAdminPage, sourceApp, addContentPage, editContentPage, reportAppPage, reportPage }) => {
+    async ({ appAdminPage, sourceApp, addContentPage, editContentPage, reportAppPage, reportPage, testUserPage }) => {
       test.info().annotations.push({
         type: AnnotationType.TestId,
         description: 'Test-613',
@@ -1070,6 +1116,7 @@ test.describe('report', () => {
           visibility: 'Display Chart Only',
           groupData: fields.groupField.name,
         }),
+        security: 'Public',
       });
 
       await test.step("Navigate to the app's reports home page", async () => {
@@ -1080,10 +1127,14 @@ test.describe('report', () => {
         await reportAppPage.createReport(report);
         await reportAppPage.page.waitForURL(reportPage.pathRegex);
         await reportPage.waitUntilLoaded();
+
+        report.id = reportPage.getReportIdFromUrl();
+        expect(report.id).not.toBe(0);
       });
 
       await test.step('Verify the spline chart displays as expected', async () => {
-        await expect(reportPage.reportContents).toHaveScreenshot();
+        const reportContents = await getReportContentsForScreenshot({ testUserPage, report });
+        await expect(reportContents).toHaveScreenshot();
       });
     }
   );
@@ -1093,7 +1144,7 @@ test.describe('report', () => {
     {
       tag: [Tags.Snapshot],
     },
-    async ({ appAdminPage, sourceApp, addContentPage, editContentPage, reportAppPage, reportPage }) => {
+    async ({ appAdminPage, sourceApp, addContentPage, editContentPage, reportAppPage, reportPage, testUserPage }) => {
       test.info().annotations.push({
         type: AnnotationType.TestId,
         description: 'Test-614',
@@ -1114,6 +1165,7 @@ test.describe('report', () => {
           visibility: 'Display Chart Only',
           groupData: fields.groupField.name,
         }),
+        security: 'Public',
       });
 
       await test.step("Navigate to the app's reports home page", async () => {
@@ -1124,10 +1176,14 @@ test.describe('report', () => {
         await reportAppPage.createReport(report);
         await reportAppPage.page.waitForURL(reportPage.pathRegex);
         await reportPage.waitUntilLoaded();
+
+        report.id = reportPage.getReportIdFromUrl();
+        expect(report.id).not.toBe(0);
       });
 
       await test.step('Verify the funnel chart displays as expected', async () => {
-        await expect(reportPage.reportContents).toHaveScreenshot();
+        const reportContents = await getReportContentsForScreenshot({ testUserPage, report });
+        await expect(reportContents).toHaveScreenshot();
       });
     }
   );
@@ -1137,7 +1193,7 @@ test.describe('report', () => {
     {
       tag: [Tags.Snapshot],
     },
-    async ({ appAdminPage, sourceApp, addContentPage, editContentPage, reportAppPage, reportPage }) => {
+    async ({ appAdminPage, sourceApp, addContentPage, editContentPage, reportAppPage, reportPage, testUserPage }) => {
       test.info().annotations.push({
         type: AnnotationType.TestId,
         description: 'Test-615',
@@ -1158,6 +1214,7 @@ test.describe('report', () => {
           visibility: 'Display Chart Only',
           groupData: fields.groupField.name,
         }),
+        security: 'Public',
       });
 
       await test.step("Navigate to the app's reports home page", async () => {
@@ -1168,10 +1225,14 @@ test.describe('report', () => {
         await reportAppPage.createReport(report);
         await reportAppPage.page.waitForURL(reportPage.pathRegex);
         await reportPage.waitUntilLoaded();
+
+        report.id = reportPage.getReportIdFromUrl();
+        expect(report.id).not.toBe(0);
       });
 
       await test.step('Verify the pyramid chart displays as expected', async () => {
-        await expect(reportPage.reportContents).toHaveScreenshot();
+        const reportContents = await getReportContentsForScreenshot({ testUserPage, report });
+        await expect(reportContents).toHaveScreenshot();
       });
     }
   );
@@ -1181,7 +1242,7 @@ test.describe('report', () => {
     {
       tag: [Tags.Snapshot],
     },
-    async ({ appAdminPage, sourceApp, addContentPage, editContentPage, reportAppPage, reportPage }) => {
+    async ({ appAdminPage, sourceApp, addContentPage, editContentPage, reportAppPage, reportPage, testUserPage }) => {
       test.info().annotations.push({
         type: AnnotationType.TestId,
         description: 'Test-616',
@@ -1203,6 +1264,7 @@ test.describe('report', () => {
           groupData: fields.groupField.name,
           seriesData: fields.seriesField.name,
         }),
+        security: 'Public',
       });
 
       await test.step("Navigate to the app's reports home page", async () => {
@@ -1213,10 +1275,14 @@ test.describe('report', () => {
         await reportAppPage.createReport(report);
         await reportAppPage.page.waitForURL(reportPage.pathRegex);
         await reportPage.waitUntilLoaded();
+
+        report.id = reportPage.getReportIdFromUrl();
+        expect(report.id).not.toBe(0);
       });
 
       await test.step('Verify the stacked bar chart displays as expected', async () => {
-        await expect(reportPage.reportContents).toHaveScreenshot();
+        const reportContents = await getReportContentsForScreenshot({ testUserPage, report });
+        await expect(reportContents).toHaveScreenshot();
       });
     }
   );
@@ -1226,7 +1292,15 @@ test.describe('report', () => {
     {
       tag: [Tags.Snapshot],
     },
-    async ({ appAdminPage, addContentPage, editContentPage, reportAppPage, reportPage, sysAdminPage }) => {
+    async ({
+      appAdminPage,
+      addContentPage,
+      editContentPage,
+      reportAppPage,
+      reportPage,
+      sysAdminPage,
+      testUserPage,
+    }) => {
       test.info().annotations.push({
         type: AnnotationType.TestId,
         description: 'Test-617',
@@ -1255,6 +1329,7 @@ test.describe('report', () => {
           visibility: 'Display Chart Only',
           groupData: fields.groupField.name,
         }),
+        security: 'Public',
       });
 
       const columnReport = new SavedReportAsChart({
@@ -1266,6 +1341,7 @@ test.describe('report', () => {
           seriesData: fields.seriesField.name,
           lineChart: lineReport,
         }),
+        security: 'Public',
       });
 
       await test.step("Navigate to the app's reports home page", async () => {
@@ -1282,19 +1358,27 @@ test.describe('report', () => {
       });
 
       await test.step('Create the column report', async () => {
-        await reportPage.page.route(
-          /Report\/\d+\/GetReportDisplayConfig/,
-          async route => await mockLineChartSeriesName(route, appName, mockAppName),
-          { times: 1 }
-        );
-
         await reportAppPage.createReport(columnReport);
         await reportAppPage.page.waitForURL(reportPage.pathRegex);
         await reportPage.waitUntilLoaded();
+
+        columnReport.id = reportPage.getReportIdFromUrl();
+        expect(columnReport.id).not.toBe(0);
       });
 
       await test.step('Verify the column plus line chart displays as expected', async () => {
-        await expect(reportPage.reportContents).toHaveScreenshot();
+        const reportContents = await getReportContentsForScreenshot({
+          testUserPage,
+          report: columnReport,
+          beforeNavigation: async rp => {
+            await rp.page.route(
+              /Report\/\d+\/GetReportDisplayConfig/,
+              async route => await mockLineChartSeriesName(route, appName, mockAppName),
+              { times: 1 }
+            );
+          },
+        });
+        await expect(reportContents).toHaveScreenshot();
       });
     }
   );
@@ -1304,7 +1388,7 @@ test.describe('report', () => {
     {
       tag: [Tags.Snapshot],
     },
-    async ({ appAdminPage, sourceApp, addContentPage, editContentPage, reportAppPage, reportPage }) => {
+    async ({ appAdminPage, sourceApp, addContentPage, editContentPage, reportAppPage, reportPage, testUserPage }) => {
       test.info().annotations.push({
         type: AnnotationType.TestId,
         description: 'Test-618',
@@ -1326,6 +1410,7 @@ test.describe('report', () => {
           groupData: fields.groupField.name,
           seriesData: fields.seriesField.name,
         }),
+        security: 'Public',
       });
 
       await test.step("Navigate to the app's reports home page", async () => {
@@ -1336,10 +1421,14 @@ test.describe('report', () => {
         await reportAppPage.createReport(report);
         await reportAppPage.page.waitForURL(reportPage.pathRegex);
         await reportPage.waitUntilLoaded();
+
+        report.id = reportPage.getReportIdFromUrl();
+        expect(report.id).not.toBe(0);
       });
 
       await test.step('Verify the stacked column chart displays as expected', async () => {
-        await expect(reportPage.reportContents).toHaveScreenshot();
+        const reportContents = await getReportContentsForScreenshot({ testUserPage, report });
+        await expect(reportContents).toHaveScreenshot();
       });
     }
   );
@@ -1349,7 +1438,15 @@ test.describe('report', () => {
     {
       tag: [Tags.Snapshot],
     },
-    async ({ appAdminPage, addContentPage, editContentPage, reportAppPage, reportPage, sysAdminPage }) => {
+    async ({
+      appAdminPage,
+      addContentPage,
+      editContentPage,
+      reportAppPage,
+      reportPage,
+      sysAdminPage,
+      testUserPage,
+    }) => {
       test.info().annotations.push({
         type: AnnotationType.TestId,
         description: 'Test-619',
@@ -1378,6 +1475,7 @@ test.describe('report', () => {
           visibility: 'Display Chart Only',
           groupData: fields.groupField.name,
         }),
+        security: 'Public',
       });
 
       const stackedColumnReport = new SavedReportAsChart({
@@ -1389,6 +1487,7 @@ test.describe('report', () => {
           seriesData: fields.seriesField.name,
           lineChart: lineReport,
         }),
+        security: 'Public',
       });
 
       await test.step("Navigate to the app's reports home page", async () => {
@@ -1405,19 +1504,27 @@ test.describe('report', () => {
       });
 
       await test.step('Create the stacked column plus line report', async () => {
-        await reportPage.page.route(
-          /Report\/\d+\/GetReportDisplayConfig/,
-          async route => await mockLineChartSeriesName(route, appName, mockAppName),
-          { times: 1 }
-        );
-
         await reportAppPage.createReport(stackedColumnReport);
         await reportAppPage.page.waitForURL(reportPage.pathRegex);
         await reportPage.waitUntilLoaded();
+
+        stackedColumnReport.id = reportPage.getReportIdFromUrl();
+        expect(stackedColumnReport.id).not.toBe(0);
       });
 
       await test.step('Verify the stacked column plus line chart displays as expected', async () => {
-        await expect(reportPage.reportContents).toHaveScreenshot();
+        const reportContents = await getReportContentsForScreenshot({
+          testUserPage,
+          report: stackedColumnReport,
+          beforeNavigation: async rp => {
+            await rp.page.route(
+              /Report\/\d+\/GetReportDisplayConfig/,
+              async route => await mockLineChartSeriesName(route, appName, mockAppName),
+              { times: 1 }
+            );
+          },
+        });
+        await expect(reportContents).toHaveScreenshot();
       });
     }
   );
@@ -1427,7 +1534,7 @@ test.describe('report', () => {
     {
       tag: [Tags.Snapshot],
     },
-    async ({ appAdminPage, sourceApp, addContentPage, editContentPage, reportAppPage, reportPage }) => {
+    async ({ appAdminPage, sourceApp, addContentPage, editContentPage, reportAppPage, reportPage, testUserPage }) => {
       test.info().annotations.push({
         type: AnnotationType.TestId,
         description: 'Test-620',
@@ -1450,6 +1557,7 @@ test.describe('report', () => {
           seriesData: fields.seriesField.name,
           additionalGroupData: fields.additionalGroupField.name,
         }),
+        security: 'Public',
       });
 
       await test.step("Navigate to the app's reports home page", async () => {
@@ -1460,10 +1568,14 @@ test.describe('report', () => {
         await reportAppPage.createReport(report);
         await reportAppPage.page.waitForURL(reportPage.pathRegex);
         await reportPage.waitUntilLoaded();
+
+        report.id = reportPage.getReportIdFromUrl();
+        expect(report.id).not.toBe(0);
       });
 
       await test.step('Verify the bubble chart displays as expected', async () => {
-        await expect(reportPage.reportContents).toHaveScreenshot();
+        const reportContents = await getReportContentsForScreenshot({ testUserPage, report });
+        await expect(reportContents).toHaveScreenshot();
       });
     }
   );
@@ -1473,7 +1585,7 @@ test.describe('report', () => {
     {
       tag: [Tags.Snapshot],
     },
-    async ({ appAdminPage, sourceApp, addContentPage, editContentPage, reportAppPage, reportPage }) => {
+    async ({ appAdminPage, sourceApp, addContentPage, editContentPage, reportAppPage, reportPage, testUserPage }) => {
       test.info().annotations.push({
         type: AnnotationType.TestId,
         description: 'Test-621',
@@ -1499,6 +1611,7 @@ test.describe('report', () => {
             { value: 6, color: '#800080' },
           ],
         }),
+        security: 'Public',
       });
 
       await test.step("Navigate to the app's reports home page", async () => {
@@ -1509,10 +1622,14 @@ test.describe('report', () => {
         await reportAppPage.createReport(report);
         await reportAppPage.page.waitForURL(reportPage.pathRegex);
         await reportPage.waitUntilLoaded();
+
+        report.id = reportPage.getReportIdFromUrl();
+        expect(report.id).not.toBe(0);
       });
 
       await test.step('Verify the heat map chart displays as expected', async () => {
-        await expect(reportPage.reportContents).toHaveScreenshot();
+        const reportContents = await getReportContentsForScreenshot({ testUserPage, report });
+        await expect(reportContents).toHaveScreenshot();
       });
     }
   );
@@ -1522,7 +1639,7 @@ test.describe('report', () => {
     {
       tag: [Tags.Snapshot],
     },
-    async ({ appAdminPage, sourceApp, addContentPage, editContentPage, reportAppPage, reportPage }) => {
+    async ({ appAdminPage, sourceApp, addContentPage, editContentPage, reportAppPage, reportPage, testUserPage }) => {
       test.info().annotations.push({
         type: AnnotationType.TestId,
         description: 'Test-622',
@@ -1602,6 +1719,7 @@ test.describe('report', () => {
           },
         ],
         defaultView: 'Day',
+        security: 'Public',
       });
 
       await test.step('Create the report', async () => {
@@ -1609,11 +1727,20 @@ test.describe('report', () => {
         await reportAppPage.page.waitForURL(reportPage.pathRegex);
         await reportPage.calendarChart.selectDate(testDate);
         await reportPage.waitUntilLoaded();
+
+        report.id = reportPage.getReportIdFromUrl();
+        expect(report.id).not.toBe(0);
       });
 
       await test.step('Verify the calendar displays as expected', async () => {
-        await reportPage.page.mouse.move(0, 0);
-        await expect(reportPage.reportContents).toHaveScreenshot();
+        const reportContents = await getReportContentsForScreenshot({
+          testUserPage,
+          report,
+          afterNavigation: async rp => {
+            await rp.calendarChart.selectDate(testDate);
+          },
+        });
+        await expect(reportContents).toHaveScreenshot();
       });
     }
   );
@@ -1623,7 +1750,7 @@ test.describe('report', () => {
     {
       tag: [Tags.Snapshot],
     },
-    async ({ appAdminPage, sourceApp, addContentPage, editContentPage, reportAppPage, reportPage }) => {
+    async ({ appAdminPage, sourceApp, addContentPage, editContentPage, reportAppPage, reportPage, testUserPage }) => {
       test.info().annotations.push({
         type: AnnotationType.TestId,
         description: 'Test-623',
@@ -1698,16 +1825,21 @@ test.describe('report', () => {
             color: '#FF0000',
           },
         ],
+        security: 'Public',
       });
 
       await test.step('Create the report', async () => {
         await reportAppPage.createReport(report);
         await reportAppPage.page.waitForURL(reportPage.pathRegex);
         await reportPage.waitUntilLoaded();
+
+        report.id = reportPage.getReportIdFromUrl();
+        expect(report.id).not.toBe(0);
       });
 
       await test.step('Verify the gantt chart displays as expected', async () => {
-        await expect(reportPage.reportContents).toHaveScreenshot();
+        const reportContents = await getReportContentsForScreenshot({ testUserPage, report });
+        await expect(reportContents).toHaveScreenshot();
       });
     }
   );
@@ -1725,6 +1857,7 @@ test.describe('report', () => {
       viewContentPage,
       reportAppPage,
       reportPage,
+      testUserPage,
     }) => {
       test.info().annotations.push({
         type: AnnotationType.TestId,
@@ -1870,16 +2003,21 @@ test.describe('report', () => {
         visibility: 'Display Map Only',
         markerNameField: 'Record Id',
         selectedColor: '#FF0000',
+        security: 'Public',
       });
 
       await test.step('Create the report', async () => {
         await reportAppPage.createReport(report);
         await reportAppPage.page.waitForURL(reportPage.pathRegex);
         await reportPage.waitUntilLoaded();
+
+        report.id = reportPage.getReportIdFromUrl();
+        expect(report.id).not.toBe(0);
       });
 
       await test.step('Verify the point map displays as expected', async () => {
-        await expect(reportPage.reportContents).toHaveScreenshot();
+        const reportContents = await getReportContentsForScreenshot({ testUserPage, report });
+        await expect(reportContents).toHaveScreenshot({ maxDiffPixels: 14 });
       });
     }
   );
@@ -1984,6 +2122,7 @@ test.describe('report', () => {
     editContentPage,
     reportAppPage,
     reportPage,
+    testUserPage,
   }) => {
     test.info().annotations.push({
       type: AnnotationType.TestId,
@@ -2006,6 +2145,7 @@ test.describe('report', () => {
         groupData: fields.groupField.name,
         seriesData: fields.seriesField.name,
       }),
+      security: 'Public',
     });
 
     await test.step("Navigate to the app's reports home page", async () => {
@@ -2016,10 +2156,14 @@ test.describe('report', () => {
       await reportAppPage.createReport(report);
       await reportAppPage.page.waitForURL(reportPage.pathRegex);
       await reportPage.waitUntilLoaded();
+
+      report.id = reportPage.getReportIdFromUrl();
+      expect(report.id).not.toBe(0);
     });
 
     await test.step('Verify the heat map chart displays as expected', async () => {
-      await expect(reportPage.reportContents).toHaveScreenshot({ maxDiffPixels: 400 });
+      const reportContents = await getReportContentsForScreenshot({ testUserPage, report });
+      await expect(reportContents).toHaveScreenshot({ maxDiffPixels: 400 });
     });
   });
 });
@@ -2229,4 +2373,31 @@ async function mockLineChartSeriesName(route: Route, appName: string, mockAppNam
   lineChartSeries.seriesName = mockAppName;
 
   await route.fulfill({ response, json: body });
+}
+
+async function getReportContentsForScreenshot({
+  testUserPage,
+  report,
+  beforeNavigation,
+  afterNavigation,
+}: {
+  testUserPage: Page;
+  report: Report;
+  beforeNavigation?: (reportPage: ReportPage) => Promise<void>;
+  afterNavigation?: (reportPage: ReportPage) => Promise<void>;
+}) {
+  const reportPage = new ReportPage(testUserPage);
+
+  if (beforeNavigation) {
+    await beforeNavigation(reportPage);
+  }
+
+  await reportPage.goto(report.id!);
+
+  if (afterNavigation) {
+    await afterNavigation(reportPage);
+  }
+
+  await reportPage.page.mouse.move(0, 0);
+  return reportPage.reportContents;
 }


### PR DESCRIPTION
- **fix: run npm audit fix**
- **fix: use a different user context to capture screenshots to avoid message alert bell causing issues with screenshot comparisons**
